### PR TITLE
💄design: #7 헤더, 사이드바, 메인 영역 구분

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Navbar from '../components/navbar/navbar';
 import Sidebar from '../components/sidebar/sidebar';
 
 export default function DashboardLayout({
@@ -8,11 +9,12 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      {/* // TODO - Navbar */}
+    <div className="flex h-screen w-screen overflow-hidden">
       <Sidebar />
-      {/* // TODO - main 스타일 조정 */}
-      <main>{children}</main>
-    </>
+      <div className="w-full">
+        <Navbar />
+        <main className="h-full overflow-auto bg-gray-300">{children}</main>
+      </div>
+    </div>
   );
 }

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -1,0 +1,7 @@
+export default function Navbar() {
+  return (
+    <header className="sticky top-0 z-10 h-[60px] border-b border-gray-300 bg-white md:h-[70px]">
+      네비게이션바
+    </header>
+  );
+}

--- a/app/components/sidebar/sidebar.tsx
+++ b/app/components/sidebar/sidebar.tsx
@@ -8,7 +8,7 @@ import SidebarDashboardList from './sidebar-dashboard-list';
 
 export default function Sidebar() {
   return (
-    <aside className="fixed h-full w-[67px] border-r border-gray-300 md:w-40 xl:w-[300px]">
+    <aside className="flex h-full w-[67px] flex-shrink-0 flex-col border-r border-gray-300 md:w-40 xl:w-[300px]">
       <div className="my-5 flex flex-col items-center justify-center md:mx-[14px] xl:items-stretch">
         <Link href="/dashboard" className="mb-[38px] md:mb-14 xl:mb-[60px]">
           <div className="flex items-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,26 +14,25 @@ const handleDashboardClick = () => {
 
 export default function Home() {
   return (
-
     <div className="flex flex-col items-center justify-center bg-gray-400">
-      랜딩페이지
-    // NOTE - 테스트 코드
-    <div className="flex h-screen items-center justify-center">
-      <Buttons
-        variant="loginSignup"
-        className="mr-4 bg-violet-primary text-white"
-        onClick={handleSignUpClick}
-      >
-        로그인
-      </Buttons>
+      랜딩페이지 // NOTE - 테스트 코드
+      <div className="flex h-screen items-center justify-center">
+        <Buttons
+          variant="loginSignup"
+          className="mr-4 bg-violet-primary text-white"
+          onClick={handleSignUpClick}
+        >
+          로그인
+        </Buttons>
 
-      <Buttons
-        variant="dashboardFirst"
-        className="bg-violet-primary text-white"
-        onClick={handleDashboardClick}
-      >
-        생성
-      </Buttons>
+        <Buttons
+          variant="dashboardFirst"
+          className="bg-violet-primary text-white"
+          onClick={handleDashboardClick}
+        >
+          생성
+        </Buttons>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#7 

## 📝작업 내용
헤더, 사이드바, 메인 영역을 겹치지 않게 구분하였습니다. 
main 영역에만 overflow를 설정하여, 사이드바와 헤더는 고정하고  main에서만 스크롤할 수 있도록 구현했습니다 
프리뷰 /mydashboard url 에서 확인하실 수 있습니당 
