### PR TITLE
♻️refactor: 쿠키에 있는 토큰 사용하여 대시보드 리스트 로직 수정 

### DIFF
--- a/app/api/dashboard/getDashboards.ts
+++ b/app/api/dashboard/getDashboards.ts
@@ -11,7 +11,6 @@ export default async function getDashboards() {
   const url = `${TEAM_BASE_URL}/dashboards?${params.toString()}`;
 
   const token = cookies().get('token')?.value;
-  console.log(token);
 
   try {
     const res = await fetch(url, {

--- a/app/api/dashboard/getDashboards.ts
+++ b/app/api/dashboard/getDashboards.ts
@@ -1,4 +1,5 @@
-import { ACCESS_TOKEN, TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { cookies } from 'next/headers';
 
 export default async function getDashboards() {
   const params = new URLSearchParams({
@@ -9,12 +10,15 @@ export default async function getDashboards() {
 
   const url = `${TEAM_BASE_URL}/dashboards?${params.toString()}`;
 
+  const token = cookies().get('token')?.value;
+  console.log(token);
+
   try {
     const res = await fetch(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
     });
 

--- a/constants/TEAM_BASE_URL.ts
+++ b/constants/TEAM_BASE_URL.ts
@@ -1,5 +1,1 @@
 export const TEAM_BASE_URL = 'https://sp-taskify-api.vercel.app/6-14';
-
-// NOTE - 로그인 기능 구현 전까지 사용할 테스트 토큰
-export const ACCESS_TOKEN =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Mzk1MCwidGVhbUlkIjoiNi0xNCIsImlhdCI6MTcxOTA2NjU1OCwiaXNzIjoic3AtdGFza2lmeSJ9.P1BK3gMqx09fVNkM93D45YjpxHfXTsg55IpQFNBKan0';


### PR DESCRIPTION
## #️⃣연관된 이슈
#28 

## 📝작업 내용
기존 로그인 구현 전에 사용되었던 테스트 토큰을 삭제하고 쿠키에서 토큰을 불러오는 로직으로 수정하였습니다! 

## 💬리뷰 요구사항(선택)
대시보드 리스트가 없을 때 별도의 예외처리를 아직 하지 않아서, 혹시 테스트해 보실 거라면 샘플 데이터를 넣어주시거나 
rlatjdud8796@naver.com
whdgks1260
으로 로그인하시면 됩니다 ! 
