### PR TITLE
✨feat: 회원 이미지 프로필 컴포넌트 생성

### DIFF
--- a/app/components/profile/profile-image.tsx
+++ b/app/components/profile/profile-image.tsx
@@ -5,18 +5,20 @@ interface ProfileImageProps {
   profileImageUrl: string | null;
   nickname: string;
   id: number;
+  size: string;
 }
 
 export default function ProfileImage({
   profileImageUrl,
   nickname,
   id,
+  size,
 }: ProfileImageProps) {
   const profileColor = useProfileColor(id);
   return (
     <div>
       {profileImageUrl ? (
-        <div className="relative size-[34px] rounded-full">
+        <div className={`relative size-[${size}px] rounded-full`}>
           <Image
             src={profileImageUrl}
             alt="프로필 이미지"
@@ -26,7 +28,7 @@ export default function ProfileImage({
         </div>
       ) : (
         <div
-          className="flex size-[34px] items-center justify-center rounded-full text-sm font-semibold text-white"
+          className={`flex size-[${size}px] items-center justify-center rounded-full text-sm font-semibold text-white`}
           style={{ backgroundColor: profileColor }}
         >
           {nickname.charAt(0)}

--- a/app/components/profile/profile-image.tsx
+++ b/app/components/profile/profile-image.tsx
@@ -1,19 +1,37 @@
+import { useProfileColor } from '@/hooks/useProfileColor';
 import Image from 'next/image';
 
 interface ProfileImageProps {
   profileImageUrl: string | null;
   nickname: string;
+  id: number;
 }
 
 export default function ProfileImage({
   profileImageUrl,
   nickname,
+  id,
 }: ProfileImageProps) {
-  return profileImageUrl ? (
-    <div className="relative size-[38px]">
-      <Image src={profileImageUrl} alt="프로필 이미지" fill />
+  const profileColor = useProfileColor(id);
+  return (
+    <div>
+      {profileImageUrl ? (
+        <div className="relative size-[34px] rounded-full">
+          <Image
+            src={profileImageUrl}
+            alt="프로필 이미지"
+            layout="fill"
+            className="rounded-full"
+          />
+        </div>
+      ) : (
+        <div
+          className="flex size-[34px] items-center justify-center rounded-full text-sm font-semibold text-white"
+          style={{ backgroundColor: profileColor }}
+        >
+          {nickname.charAt(0)}
+        </div>
+      )}
     </div>
-  ) : (
-    <div>프로필 이미지가 없습니다 {nickname}</div>
   );
 }

--- a/app/components/profile/profile-image.tsx
+++ b/app/components/profile/profile-image.tsx
@@ -1,0 +1,19 @@
+import Image from 'next/image';
+
+interface ProfileImageProps {
+  profileImageUrl: string | null;
+  nickname: string;
+}
+
+export default function ProfileImage({
+  profileImageUrl,
+  nickname,
+}: ProfileImageProps) {
+  return profileImageUrl ? (
+    <div className="relative size-[38px]">
+      <Image src={profileImageUrl} alt="프로필 이미지" fill />
+    </div>
+  ) : (
+    <div>프로필 이미지가 없습니다 {nickname}</div>
+  );
+}

--- a/app/components/profile/profile-image.tsx
+++ b/app/components/profile/profile-image.tsx
@@ -18,18 +18,16 @@ export default function ProfileImage({
   return (
     <div>
       {profileImageUrl ? (
-        <div className={`relative size-[${size}px] rounded-full`}>
-          <Image
-            src={profileImageUrl}
-            alt="프로필 이미지"
-            layout="fill"
-            className="rounded-full"
-          />
+        <div
+          className="relative size-[34px] rounded-full"
+          style={{ width: size, height: size }}
+        >
+          <Image src={profileImageUrl} alt="프로필 이미지" fill />
         </div>
       ) : (
         <div
-          className={`flex size-[${size}px] items-center justify-center rounded-full text-sm font-semibold text-white`}
-          style={{ backgroundColor: profileColor }}
+          className="flex size-[34px] items-center justify-center rounded-full text-sm font-semibold text-white"
+          style={{ backgroundColor: profileColor, width: size, height: size }}
         >
           {nickname.charAt(0)}
         </div>

--- a/app/components/sidebar/sidebar-profile.tsx
+++ b/app/components/sidebar/sidebar-profile.tsx
@@ -13,7 +13,7 @@ export default function SidebarProfile() {
         nickname={nickname}
         profileImageUrl={profileImageUrl}
         id={id}
-        size="34"
+        size="34px"
       />
     </section>
   );

--- a/app/components/sidebar/sidebar-profile.tsx
+++ b/app/components/sidebar/sidebar-profile.tsx
@@ -1,0 +1,15 @@
+import ProfileImage from '../profile/profile-image';
+
+export default function SidebarProfile() {
+  // NOTE - 테스트 유저 정보
+  // TODO - 로그인 시 user 정보를 전역 상태에 저장?
+  const nickname = '서영';
+  const profileImageUrl = null;
+
+  return (
+    <section>
+      <ProfileImage nickname={nickname} profileImageUrl={profileImageUrl} />
+      
+    </section>
+  );
+}

--- a/app/components/sidebar/sidebar-profile.tsx
+++ b/app/components/sidebar/sidebar-profile.tsx
@@ -13,6 +13,7 @@ export default function SidebarProfile() {
         nickname={nickname}
         profileImageUrl={profileImageUrl}
         id={id}
+        size="34"
       />
     </section>
   );

--- a/app/components/sidebar/sidebar-profile.tsx
+++ b/app/components/sidebar/sidebar-profile.tsx
@@ -5,11 +5,15 @@ export default function SidebarProfile() {
   // TODO - 로그인 시 user 정보를 전역 상태에 저장?
   const nickname = '서영';
   const profileImageUrl = null;
+  const id = 3950;
 
   return (
     <section>
-      <ProfileImage nickname={nickname} profileImageUrl={profileImageUrl} />
-      
+      <ProfileImage
+        nickname={nickname}
+        profileImageUrl={profileImageUrl}
+        id={id}
+      />
     </section>
   );
 }

--- a/app/components/sidebar/sidebar.tsx
+++ b/app/components/sidebar/sidebar.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import SidebarDashboardList from './sidebar-dashboard-list';
+import SidebarProfile from './sidebar-profile';
 
 export default function Sidebar() {
   return (
@@ -23,7 +24,7 @@ export default function Sidebar() {
             </div>
           </div>
         </Link>
-        {/* // TODO - 프로필 section */}
+        <SidebarProfile />
         <section />
         <div className="mb-[38px] flex items-center justify-between md:mb-[30px] md:w-full">
           <p className="flex hidden text-xs font-bold text-gray-500 md:block">

--- a/constants/profileColorList.ts
+++ b/constants/profileColorList.ts
@@ -1,5 +1,5 @@
 export const PROFILE_COLOR_LIST = [
-  '#D6173A',
+  '#787486',
   '#7AC555',
   '#760DDE',
   '#FFA500',

--- a/constants/profileColorList.ts
+++ b/constants/profileColorList.ts
@@ -1,0 +1,8 @@
+export const PROFILE_COLOR_LIST = [
+  '#D6173A',
+  '#7AC555',
+  '#760DDE',
+  '#FFA500',
+  '#76A5EA',
+  '#E876EA',
+];

--- a/hooks/useProfileColor.ts
+++ b/hooks/useProfileColor.ts
@@ -1,6 +1,6 @@
 import { PROFILE_COLOR_LIST } from '@/constants/profileColorList';
 
-const useProfileColor = (id: number) => {
+export const useProfileColor = (id: number) => {
   const lastNumber = id % 10;
 
   if (lastNumber === 0 || lastNumber === 5) {

--- a/hooks/useProfileColor.ts
+++ b/hooks/useProfileColor.ts
@@ -1,0 +1,19 @@
+import { PROFILE_COLOR_LIST } from '@/constants/profileColorList';
+
+const useProfileColor = (id: number) => {
+  const lastNumber = id % 10;
+
+  if (lastNumber === 0 || lastNumber === 5) {
+    return PROFILE_COLOR_LIST[0];
+  } else if (lastNumber === 1) {
+    return PROFILE_COLOR_LIST[1];
+  } else if (lastNumber === 2 || lastNumber === 6) {
+    return PROFILE_COLOR_LIST[2];
+  } else if (lastNumber === 3 || lastNumber === 7) {
+    return PROFILE_COLOR_LIST[3];
+  } else if (lastNumber === 4 || lastNumber === 8) {
+    return PROFILE_COLOR_LIST[4];
+  } else {
+    return PROFILE_COLOR_LIST[5];
+  }
+};

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#27 

## 📝작업 내용
대시보드 참여자들, 로그인 유저 프로필에 필요한 공통 컴포넌트입니다. 
![image](https://github.com/Sprint-Part3-14Team/14team-project/assets/135966211/67555a1b-8bdb-4440-9a9a-1792b9f19492)
대시보드 참여자 목록에서 친절하게 참여자들 관련한 정보들을 다 주더라구요.! 
- 프로필 이미지가 있는 경우에는 image src에 사용
- 없는 경우에는 id를 통해서 랜덤으로 색상을 지정하고(custom hook 으로 구현) 
- 닉네임 첫글자 사용해서 구글처럼 구현해 보았습니다.  

로그인 후 user를 전역 객체로 관리해야 할 거 같은데요 ! 저는 우선 샘플 데이터로 진행했습니다. 

사이드바 마진 등은 아직 조정하지 않은 상태입니다 .

## 📷스크린샷 (선택)
<img src="https://github.com/Sprint-Part3-14Team/14team-project/assets/135966211/43f86442-bfb2-434d-8877-ac141780ad93" width="50%" height="50%"/>

## 💬리뷰 요구사항(선택)
코맨트로 달아두겠습니다 !! 
(+) 삘받아서 늦게까지 작업 진행했는데 혹시나 잠결에 깃허브 알람 거슬리셨다면 죄송합니다 😭
