### PR TITLE
💄design: mydashboard 대시보드 리스트 디자인 구현 및 데이터 패칭 리팩토링

### DIFF
--- a/app/(dashboard)/dashboard/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/[id]/page.tsx
@@ -33,69 +33,69 @@ const dummyCardsOne: Cards[] = [
       'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/132.png',
     createdAt: new Date(),
   },
-  // {
-  //   id: 4,
-  //   title: 'Card 4',
-  //   tags: ['tag7', 'tag8', 'tag9'],
-  //   assignee: {
-  //     profileImageUrl: '',
-  //     nickname: 'User4',
-  //     id: 4,
-  //   },
-  //   imageUrl:
-  //     'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png',
-  //   createdAt: new Date(),
-  // },
-  // {
-  //   id: 6,
-  //   title: 'Card 6',
-  //   tags: ['tag11', 'tag12'],
-  //   assignee: {
-  //     profileImageUrl: '',
-  //     nickname: 'User6',
-  //     id: 6,
-  //   },
-  //   imageUrl: '',
-  //   createdAt: new Date(),
-  // },
-  // {
-  //   id: 8,
-  //   title: 'Card 8',
-  //   tags: ['tag15', 'tag16'],
-  //   assignee: {
-  //     profileImageUrl: '',
-  //     nickname: 'User8',
-  //     id: 8,
-  //   },
-  //   imageUrl:
-  //     'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/389.png',
-  //   createdAt: new Date(),
-  // },
-  // {
-  //   id: 10,
-  //   title: 'Card 10',
-  //   tags: ['tag19', 'tag20'],
-  //   assignee: {
-  //     profileImageUrl: '',
-  //     nickname: 'User10',
-  //     id: 10,
-  //   },
-  //   imageUrl: '',
-  //   createdAt: new Date(),
-  // },
-  // {
-  //   id: 10,
-  //   title: 'Card 10',
-  //   tags: ['tag19', 'tag20'],
-  //   assignee: {
-  //     profileImageUrl: '',
-  //     nickname: 'User10',
-  //     id: 10,
-  //   },
-  //   imageUrl:
-  //     'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png',
-  //   createdAt: new Date(),
-  // },
+  {
+    id: 4,
+    title: 'Card 4',
+    tags: ['tag7', 'tag8', 'tag9'],
+    assignee: {
+      profileImageUrl: '',
+      nickname: 'User4',
+      id: 4,
+    },
+    imageUrl:
+      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png',
+    createdAt: new Date(),
+  },
+  {
+    id: 6,
+    title: 'Card 6',
+    tags: ['tag11', 'tag12'],
+    assignee: {
+      profileImageUrl: '',
+      nickname: 'User6',
+      id: 6,
+    },
+    imageUrl: '',
+    createdAt: new Date(),
+  },
+  {
+    id: 8,
+    title: 'Card 8',
+    tags: ['tag15', 'tag16'],
+    assignee: {
+      profileImageUrl: '',
+      nickname: 'User8',
+      id: 8,
+    },
+    imageUrl:
+      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/389.png',
+    createdAt: new Date(),
+  },
+  {
+    id: 10,
+    title: 'Card 10',
+    tags: ['tag19', 'tag20'],
+    assignee: {
+      profileImageUrl: '',
+      nickname: 'User10',
+      id: 10,
+    },
+    imageUrl: '',
+    createdAt: new Date(),
+  },
+  {
+    id: 10,
+    title: 'Card 10',
+    tags: ['tag19', 'tag20'],
+    assignee: {
+      profileImageUrl: '',
+      nickname: 'User10',
+      id: 10,
+    },
+    imageUrl:
+      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png',
+    createdAt: new Date(),
+  },
 ];
 
 const dummyCardsTwo: Cards[] = [

--- a/app/(dashboard)/mydashboard/_components/dashboard-card.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboard-card.tsx
@@ -1,0 +1,28 @@
+import ProfileImage from '@/app/components/profile/profile-image';
+import { Dashboard } from '@/types/dashboard';
+import { User } from '@/types/user';
+
+interface DashboardProps {
+  dashboard: Dashboard;
+  user: User;
+}
+
+export default function DashboardCard({ dashboard, user }: DashboardProps) {
+  return (
+    <li className="h-20[90px] relative flex items-center justify-between rounded-lg border border-gray-300 bg-white px-5 py-5">
+      <div
+        className="absolute left-0 top-[50%] h-7 w-1 translate-y-[-50%] rounded-r-lg"
+        style={{ backgroundColor: dashboard.color }}
+      />
+      <p className="text-sm font-semibold text-gray-700">{dashboard.title}</p>
+      {dashboard.createdByMe && (
+        <ProfileImage
+          nickname={user.nickname}
+          profileImageUrl={user.profileImageUrl}
+          id={user.id}
+          size="20px"
+        />
+      )}
+    </li>
+  );
+}

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -1,7 +1,8 @@
-import ProfileImage from '@/app/components/profile/profile-image';
 import getFetcher from '@/lib/api/getFetcher';
 import getUserMeFetcher from '@/lib/api/getUserMeFetcher';
 import { Dashboard } from '@/types/dashboard';
+
+import DashboardCard from './dashboard-card';
 
 export default async function DashBoards() {
   const params = new URLSearchParams({
@@ -11,33 +12,20 @@ export default async function DashBoards() {
   });
 
   const data = await getFetcher(`/dashboards?${params.toString()}`);
-  const { dashboards } = data;
+  const { dashboards, totalCount } = data;
 
   // NOTE - 사용자 정보 GET
   const user = await getUserMeFetcher();
 
   return (
     <section>
-      <p>{user.id}</p>
+      <div className="mb-3 flex items-center gap-1 text-xs">
+        <h2 className="text-xl font-bold">Dashboard</h2>
+        <p>{totalCount}</p>
+      </div>
       <ul className="flex flex-col gap-2">
         {dashboards.map((dashboard: Dashboard) => (
-          <li className="h-20[90px] relative flex items-center justify-between rounded-lg border border-gray-300 bg-white px-5 py-5">
-            <div
-              className="absolute left-0 top-[50%] h-7 w-1 translate-y-[-50%] rounded-r-lg"
-              style={{ backgroundColor: dashboard.color }}
-            />
-            <p className="text-sm font-semibold text-gray-700">
-              {dashboard.title}
-            </p>
-            {dashboard.createdByMe && (
-              <ProfileImage
-                nickname={user.nickname}
-                profileImageUrl={user.profileImageUrl}
-                id={user.id}
-                size="20px"
-              />
-            )}
-          </li>
+          <DashboardCard dashboard={dashboard} user={user} />
         ))}
       </ul>
     </section>

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -1,4 +1,5 @@
 import getFetcher from '@/lib/api/getFetcher';
+import getUserMeFetcher from '@/lib/api/getUserMeFetcher';
 import crown from '@/public/icons/crown_icon.svg';
 import { Dashboard } from '@/types/dashboard';
 import Image from 'next/image';
@@ -14,16 +15,18 @@ export default async function DashBoards() {
   const { dashboards } = data;
 
   // NOTE - 사용자 정보 GET
+  const user = await getUserMeFetcher();
 
   return (
     <section>
+      <p>{user.id}</p>
       <ul className="flex flex-col gap-2">
         {dashboards.map((dashboard: Dashboard) => (
           <li className="h-20[90px] relative flex rounded-lg border border-gray-300 bg-white py-5 pl-5">
             <div
               className="absolute left-0 top-[50%] h-7 w-1 translate-y-[-50%] rounded-r-lg"
               style={{ backgroundColor: dashboard.color }}
-             />
+            />
             <p>{dashboard.title}</p>
             {/* // NOTE - 만든 사람 프로필 넣기 불가능함 내가 만든 대시보드일 경우 왕관 OR 프로필 이미지(없으면 기본 프로필 이미지) */}
             {dashboard.createdByMe && (

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -21,12 +21,14 @@ export default async function DashBoards() {
       <p>{user.id}</p>
       <ul className="flex flex-col gap-2">
         {dashboards.map((dashboard: Dashboard) => (
-          <li className="h-20[90px] relative flex rounded-lg border border-gray-300 bg-white py-5 pl-5">
+          <li className="h-20[90px] relative flex items-center justify-between rounded-lg border border-gray-300 bg-white px-5 py-5">
             <div
               className="absolute left-0 top-[50%] h-7 w-1 translate-y-[-50%] rounded-r-lg"
               style={{ backgroundColor: dashboard.color }}
             />
-            <p>{dashboard.title}</p>
+            <p className="text-sm font-semibold text-gray-700">
+              {dashboard.title}
+            </p>
             {dashboard.createdByMe && (
               <ProfileImage
                 nickname={user.nickname}

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -1,5 +1,5 @@
 import getFetcher from '@/lib/api/getFetcher';
-import getUserMeFetcher from '@/lib/api/getUserMeFetcher';
+import getLoggedInUser from '@/lib/api/getLoggedInUser';
 import { Dashboard } from '@/types/dashboard';
 
 import DashboardCard from './dashboard-card';
@@ -15,7 +15,7 @@ export default async function DashBoards() {
   const { dashboards, totalCount } = data;
 
   // NOTE - 사용자 정보 GET
-  const user = await getUserMeFetcher();
+  const user = await getLoggedInUser();
 
   return (
     <section>

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -1,5 +1,7 @@
 import getFetcher from '@/lib/api/getFetcher';
+import crown from '@/public/icons/crown_icon.svg';
 import { Dashboard } from '@/types/dashboard';
+import Image from 'next/image';
 
 export default async function DashBoards() {
   const params = new URLSearchParams({
@@ -11,12 +13,24 @@ export default async function DashBoards() {
   const data = await getFetcher(`/dashboards?${params.toString()}`);
   const { dashboards } = data;
 
+  // NOTE - 사용자 정보 GET
+
   return (
     <section>
-      <ul className="">
+      <ul className="flex flex-col gap-2">
         {dashboards.map((dashboard: Dashboard) => (
-          <li>
+          <li className="h-20[90px] relative flex rounded-lg border border-gray-300 bg-white py-5 pl-5">
+            <div
+              className="absolute left-0 top-[50%] h-7 w-1 translate-y-[-50%] rounded-r-lg"
+              style={{ backgroundColor: dashboard.color }}
+             />
             <p>{dashboard.title}</p>
+            {/* // NOTE - 만든 사람 프로필 넣기 불가능함 내가 만든 대시보드일 경우 왕관 OR 프로필 이미지(없으면 기본 프로필 이미지) */}
+            {dashboard.createdByMe && (
+              <div className="relative h-3 w-4">
+                <Image src={crown} alt="내가 만든 대시보드 왕관" fill />
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/app/(dashboard)/mydashboard/_components/dashboards.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboards.tsx
@@ -1,8 +1,7 @@
+import ProfileImage from '@/app/components/profile/profile-image';
 import getFetcher from '@/lib/api/getFetcher';
 import getUserMeFetcher from '@/lib/api/getUserMeFetcher';
-import crown from '@/public/icons/crown_icon.svg';
 import { Dashboard } from '@/types/dashboard';
-import Image from 'next/image';
 
 export default async function DashBoards() {
   const params = new URLSearchParams({
@@ -28,11 +27,13 @@ export default async function DashBoards() {
               style={{ backgroundColor: dashboard.color }}
             />
             <p>{dashboard.title}</p>
-            {/* // NOTE - 만든 사람 프로필 넣기 불가능함 내가 만든 대시보드일 경우 왕관 OR 프로필 이미지(없으면 기본 프로필 이미지) */}
             {dashboard.createdByMe && (
-              <div className="relative h-3 w-4">
-                <Image src={crown} alt="내가 만든 대시보드 왕관" fill />
-              </div>
+              <ProfileImage
+                nickname={user.nickname}
+                profileImageUrl={user.profileImageUrl}
+                id={user.id}
+                size="20px"
+              />
             )}
           </li>
         ))}

--- a/app/(dashboard)/mydashboard/page.tsx
+++ b/app/(dashboard)/mydashboard/page.tsx
@@ -3,8 +3,7 @@ import Invitaions from './_components/invitations';
 
 export default function MyDashboard() {
   return (
-    <main className="">
-      mydashboard 페이지
+    <main className="h-[calc(100vh-60px)] overflow-auto p-6 md:h-[calc(100vh-70px)] md:p-10">
       <DashBoards />
       <Invitaions />
     </main>

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -7,7 +7,7 @@ import ProfileImage from '../profile/profile-image';
 
 export default function Navbar() {
   // NOTE - 테스트 유저 정보
-  const nickname = '서영';
+  const nickname = '김서영';
   const profileImageUrl = null;
   const id = 3950;
 

--- a/app/components/profile/profile-image.tsx
+++ b/app/components/profile/profile-image.tsx
@@ -2,7 +2,7 @@ import { useProfileColor } from '@/hooks/useProfileColor';
 import Image from 'next/image';
 
 interface ProfileImageProps {
-  profileImageUrl: string | null;
+  profileImageUrl?: string | null;
   nickname: string;
   id: number;
   size: string;

--- a/lib/api/getLoggedInUser.ts
+++ b/lib/api/getLoggedInUser.ts
@@ -2,7 +2,7 @@ import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
 import { User } from '@/types/user';
 import { cookies } from 'next/headers';
 
-export default async function getUserMeFetcher(): Promise<User> {
+export default async function getLoggedInUser(): Promise<User> {
   const token = cookies().get('token')?.value;
 
   const res = await fetch(`${TEAM_BASE_URL}/users/me`, {

--- a/lib/api/getUserMeFetcher.ts
+++ b/lib/api/getUserMeFetcher.ts
@@ -1,0 +1,30 @@
+import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { User } from '@/types/user';
+import { cookies } from 'next/headers';
+
+export default async function getUserMeFetcher(): Promise<User> {
+  const token = cookies().get('token')?.value;
+
+  const res = await fetch(`${TEAM_BASE_URL}/users/me`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const data = await res.json();
+  const user = data as User;
+
+  if (!res.ok) {
+    switch (res.status) {
+      case 401:
+        throw new Error(data.message);
+      case 404:
+        throw new Error(data.message);
+      default:
+        throw new Error('서버 오류가 발생했습니다');
+    }
+  }
+
+  return user;
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -2,7 +2,7 @@ export interface User {
   id: number;
   email: string;
   nickname: string;
-  profileImageUrl?: string;
+  profileImageUrl: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -2,7 +2,7 @@ export interface User {
   id: number;
   email: string;
   nickname: string;
-  profileImageUrl: string | null;
+  profileImageUrl?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#56 

## 📝작업 내용
디자인하다가 중간에 멘토링 끝나고 리팩토링해서 PR을 나눴으면 조금 더 깔끔했을 거 같네요 .. ! 
브랜치 분리 조금 더 신경쓰겠습니다 ! 

토큰으로 user 정보 가져오는 API를 사용하여 로그인한 유저 정보 가져오는 로직을 생성했습니다

기존 피그마에는 내가 만든 대시보드에 왕관이 붙는데 프로필 이미지 컴포넌트 사용하여 프로필 이미지가 보이도록 변경했습니다. 

## 📷스크린샷 (선택)
<img src="https://github.com/Sprint-Part3-14Team/14team-project/assets/135966211/c3aba2d4-d7c9-4e67-b135-44f9af0c61ce" width="50%" height="50%"/>

## 💬리뷰 요구사항(선택)
아직 모바일 UI 만 구현했습니다 ! 
test 대시보드는 대시보색이 흰색이라 구분이 안 되네요! 참고해주세요 
