### PR TITLE
✨ feat: 로그인 에러 핸들링 및 빈 토큰 값 버그 수정

### DIFF
--- a/app/(auth)/_components/auth-modal.tsx
+++ b/app/(auth)/_components/auth-modal.tsx
@@ -7,28 +7,15 @@ import React from 'react';
 interface SignModalProps {
   isOpen: boolean;
   onClose: () => void;
-  variant: 'signupComplete' | 'passwordError' | 'emailDuplicate';
+  message: string;
 }
 
 export default function SignModal({
   isOpen,
   onClose,
-  variant,
+  message,
 }: SignModalProps) {
   if (!isOpen) return null;
-
-  const getMessage = () => {
-    switch (variant) {
-      case 'signupComplete':
-        return '가입이 완료되었습니다!';
-      case 'passwordError':
-        return '비밀번호가 일치하지 않습니다.';
-      case 'emailDuplicate':
-        return '이미 사용 중인 이메일입니다.';
-      default:
-        return '';
-    }
-  };
 
   return (
     <Modal
@@ -36,7 +23,7 @@ export default function SignModal({
       onClose={onClose}
       className="relative flex h-[220px] w-[327px] flex-col items-center justify-center md:h-[250px] md:w-[540px]"
     >
-      <h2 className="text-center text-base md:text-lg">{getMessage()}</h2>
+      <h2 className="text-center text-base md:text-lg">{message}</h2>
       <div className="absolute bottom-7 right-24 md:right-7">
         <Button
           onClick={onClose}

--- a/app/(auth)/_components/sign-in-form.tsx
+++ b/app/(auth)/_components/sign-in-form.tsx
@@ -3,11 +3,13 @@
 import { loginSchema } from '@/lib/schemas/auth';
 import { SignInInput } from '@/types/auth';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import InputField from '../../components/input-field';
 import signIn from '../login/actions';
+import SignModal from './auth-modal';
 import PasswordInputField from './password-input-field';
 
 export default function SignInForm() {
@@ -20,15 +22,29 @@ export default function SignInForm() {
     mode: 'onChange',
   });
 
+  const router = useRouter();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [passwordShown, setPasswordShown] = useState(false);
+
   const onSubmit: SubmitHandler<SignInInput> = async (data) => {
     const { email, password } = data;
-    await signIn(email, password);
+    const resData = await signIn(email, password);
+    if (!resData.success) {
+      setModalOpen(true);
+      setErrorMessage(resData.data.message);
+    } else {
+      router.push(resData.redirect as string);
+    }
   };
-
-  const [passwordShown, setPasswordShown] = useState(false);
 
   const togglePasswordVisibility = () => {
     setPasswordShown(!passwordShown);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
   };
 
   return (
@@ -57,6 +73,13 @@ export default function SignInForm() {
       >
         로그인
       </button>
+      {modalOpen && (
+        <SignModal
+          isOpen={modalOpen}
+          onClose={handleCloseModal}
+          message={errorMessage}
+        />
+      )}
     </form>
   );
 }

--- a/app/(auth)/_components/sign-up-form.tsx
+++ b/app/(auth)/_components/sign-up-form.tsx
@@ -3,11 +3,13 @@
 import { signUpSchema } from '@/lib/schemas/auth';
 import { SignUpInput } from '@/types/auth';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import InputField from '../../components/input-field';
 import signUp from '../signup/actions';
+import SignModal from './auth-modal';
 import PasswordInputField from './password-input-field';
 
 export default function SignUpForm() {
@@ -20,20 +22,41 @@ export default function SignUpForm() {
     mode: 'onChange',
   });
 
-  const onSubmit: SubmitHandler<SignUpInput> = async (data) => {
-    const { email, nickname, password } = data;
-    await signUp(email, nickname, password);
-  };
+  const router = useRouter();
 
   const [passwordShown, setPasswordShown] = useState(false);
   const [passwordConfirmationShown, setPasswordConfirmationShown] =
     useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [isSignUpSuccess, setIsSignUpSuccess] = useState(false);
+
+  const onSubmit: SubmitHandler<SignUpInput> = async (data) => {
+    const { email, nickname, password } = data;
+    const resData = await signUp(email, nickname, password);
+
+    setModalOpen(true);
+    if (resData.message) {
+      setMessage(resData.message);
+      setIsSignUpSuccess(false);
+    } else {
+      setMessage('가입이 완료되었습니다!');
+      setIsSignUpSuccess(true);
+    }
+  };
 
   const togglePasswordVisibility = () => {
     setPasswordShown(!passwordShown);
   };
   const togglePasswordConfirmationVisibility = () => {
     setPasswordConfirmationShown(!passwordConfirmationShown);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    if (isSignUpSuccess) {
+      router.push('/login');
+    }
   };
 
   return (
@@ -89,6 +112,13 @@ export default function SignUpForm() {
       >
         회원가입
       </button>
+      {modalOpen && (
+        <SignModal
+          isOpen={modalOpen}
+          onClose={handleCloseModal}
+          message={message}
+        />
+      )}
     </form>
   );
 }

--- a/app/(auth)/login/actions.ts
+++ b/app/(auth)/login/actions.ts
@@ -2,20 +2,27 @@
 
 import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
 import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 
 export default async function signIn(email: string, password: string) {
-  const response = await fetch(`${TEAM_BASE_URL}/auth/login`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
-  });
+  try {
+    const response = await fetch(`${TEAM_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+    });
 
-  const data = await response.json();
+    const data = await response.json();
 
-  cookies().set('token', data.accessToken);
+    if (response.status === 201) {
+      cookies().set('token', data.accessToken);
 
-  redirect('/mydashboard');
+      // 여기서 직접 redirect를 사용하면 NEXT_REDIRECT에러 발생..버그인 것 같으므로 객체로 따로 처리
+      return { success: true, redirect: '/mydashboard' };
+    }
+    return { success: false, data };
+  } catch (error) {
+    throw new Error(error as string);
+  }
 }

--- a/app/(auth)/signup/actions.ts
+++ b/app/(auth)/signup/actions.ts
@@ -1,24 +1,28 @@
 'use server';
 
 import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
-import { redirect } from 'next/navigation';
 
 export default async function signUp(
   email: string,
   nickname: string,
   password: string
 ) {
-  await fetch(`${TEAM_BASE_URL}/users`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, nickname, password }),
-  });
+  try {
+    const response = await fetch(`${TEAM_BASE_URL}/users`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, nickname, password }),
+    });
 
-  // TODO - 회원가입 시 토큰 저장을 해야하는가?
-  // const data = await response.json();
-  // cookies().set('token', data.accessToken);
+    // TODO - 회원가입 시 토큰 저장을 해야하는가?
+    // const data = await response.json();
+    // cookies().set('token', data.accessToken);
+    const data = await response.json();
 
-  redirect('/login');
+    return data;
+  } catch (error) {
+    throw new Error(error as string);
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
close #71 

## 📝작업 내용
피그마 시안에 따라 로그인 및 회원가입 에러 처리를 하였습니다.
추가로 로그인 실패 시 token이 빈 값으로 들어갔는데 이 문제를 처리하였습니다!

## 💬리뷰 요구사항(선택)
actions만 그러는지는 모르겠으나 response.status를 비교하여 서버에서 바로 redirect를 사용해 코드를 일관성 있게 작성하고 싶었으나 NEXT_REDIRECT오류로 인해 로그인과 회원가입 로직이 살짝 느낌이 달라졌습니다. (로그인은 서버에서 success를 객체로, 회원가입은 에러 메세지로 클라이언트단에서 처리)

추가로 닉네임이 중복되어도 가입이 되는데 클라이언트에서 처리할지, 닉네임 중복을 허용할지 이야기 해보면 좋을 것 같습니당

일단 모두 모달로 만들었는데 모달 대신 토스트로 처리하면 좋을 부분이 있다면 알려주시면 감사하겠습니다!