### PR TITLE
💄 design: 비슷한 모달 (생성, 관리, 초대) 디자인 구현

### DIFF
--- a/app/(dashboard)/mydashboard/_components/new-dashboard-modal.tsx
+++ b/app/(dashboard)/mydashboard/_components/new-dashboard-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Buttons from '@/app/components/button';
+import Button from '@/app/components/button';
 import ColorList from '@/app/components/color-list';
 import Modal from '@/app/components/modal';
 import { useRouter } from 'next/navigation';
@@ -73,21 +73,21 @@ export default function NewDashboardModal({
           register={(color: string) => setSelectedColor(color)}
         />
         <div className="mt-[76px] flex justify-center md:mt-[86px] md:justify-end">
-          <Buttons
+          <Button
             variant="mobile138x42"
             onClick={onClose}
             className="rounded-lg border border-solid border-gray-300 bg-white text-black"
           >
             취소
-          </Buttons>
-          <Buttons
+          </Button>
+          <Button
             variant="mobile138x42"
             type="submit"
             className={`ml-[12px] rounded-lg bg-violet-primary text-white md:mr-[28px] ${dashboardName && selectedColor ? 'cursor-default' : 'cursor-not-allowed'}`}
             disabled={!dashboardName || !selectedColor}
           >
             생성
-          </Buttons>
+          </Button>
         </div>
       </form>
     </Modal>

--- a/app/components/single-input-modal.tsx
+++ b/app/components/single-input-modal.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import Button from './button';
+import Modal from './modal';
+
+interface SingleInputModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete?: () => void;
+  title: string;
+  labelText: string;
+  buttonText: string;
+  inputId: string;
+  inputValue: string;
+  setInputValue: (value: string) => void;
+  onSubmit: () => void;
+  placeholder: string;
+}
+
+export default function SingleInputModal({
+  isOpen,
+  onClose,
+  onDelete,
+  title,
+  labelText,
+  buttonText,
+  inputId,
+  inputValue,
+  setInputValue,
+  onSubmit,
+  placeholder,
+}: SingleInputModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="w-[327px] md:w-[540px]">
+      <h2 className="ml-[20px] mt-[28px] text-xl font-bold md:ml-[28px] md:mt-[32px] md:text-2xl">
+        {title}
+      </h2>
+      <form onSubmit={onSubmit}>
+        <label
+          htmlFor={inputId}
+          className="ml-[20px] mt-[24px] block text-base font-medium text-gray-700 md:ml-[28px] md:mt-[32px] md:text-lg"
+        >
+          {labelText}
+        </label>
+        <div className="flex items-center justify-center">
+          <input
+            id={inputId}
+            type="text"
+            value={inputValue}
+            placeholder={placeholder}
+            onChange={(e) => setInputValue(e.target.value)}
+            className="mt-[10px] flex h-[42px] w-[287px] rounded-md border border-gray-300 pl-[16px] text-sm font-normal text-gray-700 md:h-[48px] md:w-[484px] md:text-base"
+          />
+        </div>
+        <div className="flex flex-col md:flex-row">
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="mb-[16px] ml-[20px] mt-[24px] flex justify-start text-sm font-normal text-gray-400 underline md:ml-[28px] md:mt-[59px]"
+            >
+              삭제하기
+            </button>
+          )}
+          <div
+            className={`${onDelete ? 'md:ml-[183px] md:mt-[28px]' : 'mt-[24px] md:ml-[260px]'} mb-[28px] flex justify-center`}
+          >
+            <Button
+              variant="mobile138x42"
+              onClick={onClose}
+              className="rounded-lg border border-solid border-gray-300 bg-white text-black"
+            >
+              취소
+            </Button>
+            <Button
+              variant="mobile138x42"
+              type="submit"
+              className="ml-[12px] rounded-lg bg-violet-primary text-white"
+            >
+              {buttonText}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#95 

## 📝작업 내용
비슷한 모달 (생성, 관리, 초대) 디자인 구현했습니다
반응형 구현했고 칼럼 관리 모달에서 삭제하기도 구현했습니다
```
      <SingleInputModal
        isOpen={isModalOpen}
        onClose={closeModal}
        title="새 칼럼 생성"
        labelText="이름"
        buttonText="생성"
        inputId={columnName}
        inputValue={columnName}
        setInputValue={setColumnName}
        // onDelete={handleDelete}
        onSubmit={handleSubmit}
        placeholder="입력하세요"
      />
```
좀 길지만 이런식으로 사용하면 됩니다!!

## 📷스크린샷 (선택)

https://github.com/Sprint-Part3-14Team/14team-project/assets/162143999/a68a9c93-aaf1-46c9-97a1-c5f809803d87

https://github.com/Sprint-Part3-14Team/14team-project/assets/162143999/77a98a49-9675-4ffa-ab13-4d07e766a4ba


## 💬리뷰 요구사항(선택)
칼럼 생성에서 "중복된 칼럼 이름입니다" 경고문은 아직 없습니다.
추후에 추가하겠습니다!!
