### PR TITLE
✨feat: #124 카드 수정 기능 구현 

### DIFF
--- a/app/(dashboard)/_components/todo-card.tsx
+++ b/app/(dashboard)/_components/todo-card.tsx
@@ -67,12 +67,15 @@ export default function ToDoCard({
               <div className="flex items-center gap-x-[6px]">
                 <div className="relative size-[22px] md:size-6">
                   {/* TODO 모바일일 때 size가 22px PC가 24px인데 어떻게 주어야 좋을까요 */}
-                  <ProfileImage
-                    profileImageUrl={props.assignee.profileImageUrl}
-                    nickname={props.assignee.nickname}
-                    id={props.assignee.id}
-                    size="24px"
-                  />
+                  {/* NOTE - 담당자 필수값 아닙니다! 없을 때도 있어요 */}
+                  {props.assignee && (
+                    <ProfileImage
+                      profileImageUrl={props.assignee.profileImageUrl}
+                      nickname={props.assignee.nickname}
+                      id={props.assignee.id}
+                      size="24px"
+                    />
+                  )}
                 </div>
               </div>
             </div>

--- a/app/(dashboard)/_components/todo-modal.tsx
+++ b/app/(dashboard)/_components/todo-modal.tsx
@@ -1,5 +1,3 @@
-// NOTE - li태그에 onClick으로 인해 주석 추가
-
 /* eslint-disable */
 'use client';
 
@@ -18,11 +16,7 @@ import AddToDoModal from '../dashboard/[id]/_components/to-do/add-to-do-modal';
 import Tag from './tag';
 import TodoModalComment from './todo-modal-comment';
 
-// NOTE - li태그에 onClick으로 인해 주석 추가
-
 /* eslint-disable */
-
-// NOTE - li태그에 onClick으로 인해 주석 추가
 
 /* eslint-disable */
 
@@ -149,7 +143,8 @@ export default function ToDoModal({
               <div className="flex-flex-col w-full">
                 <p className="text-[10px] font-semibold md:text-xs">마감일</p>
                 <p className="text-xs md:text-sm">
-                  {formatDate(new Date(props.props.dueDate))}
+                  {props.props.dueDate &&
+                    formatDate(new Date(props.props.dueDate))}
                 </p>
               </div>
             </div>
@@ -187,6 +182,7 @@ export default function ToDoModal({
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
         columnId={props.props.columnId}
+        toDoValue={props.props}
       />
     </>
   );

--- a/app/(dashboard)/_components/todo-modal.tsx
+++ b/app/(dashboard)/_components/todo-modal.tsx
@@ -20,12 +20,6 @@ import TodoModalComment from './todo-modal-comment';
 
 /* eslint-disable */
 
-/* eslint-disable */
-
-/* eslint-disable */
-
-/* eslint-disable */
-
 export default function ToDoModal({
   isOpen,
   onClose,
@@ -191,6 +185,7 @@ export default function ToDoModal({
         onClose={() => setIsEditModalOpen(false)}
         columnId={props.props.columnId}
         toDoValue={props.props}
+        cardId={props.props.id}
       />
     </>
   );

--- a/app/(dashboard)/_components/todo-modal.tsx
+++ b/app/(dashboard)/_components/todo-modal.tsx
@@ -1,3 +1,6 @@
+// NOTE - li태그에 onClick으로 인해 주석 추가
+
+/* eslint-disable */
 'use client';
 
 import ColumnTag from '@/app/components/column-tag';
@@ -11,8 +14,17 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
+import AddToDoModal from '../dashboard/[id]/_components/to-do/add-to-do-modal';
 import Tag from './tag';
 import TodoModalComment from './todo-modal-comment';
+
+// NOTE - li태그에 onClick으로 인해 주석 추가
+
+/* eslint-disable */
+
+// NOTE - li태그에 onClick으로 인해 주석 추가
+
+/* eslint-disable */
 
 export default function ToDoModal({
   isOpen,
@@ -27,6 +39,7 @@ export default function ToDoModal({
 }) {
   const [isTaskOptionOpen, setIsTaskOptionOpen] = useState(false);
   const router = useRouter();
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   async function deleteTask(cardId: number) {
     const token = getCookie('token');
@@ -49,6 +62,12 @@ export default function ToDoModal({
     router.refresh();
   }
 
+  // NOTE - 수정 모달 열기
+  const handleEditTask = () => {
+    setIsEditModalOpen(true);
+    onClose(); // 현재 모달 닫기
+  };
+
   const handleTaskOptionToggle = () => {
     setIsTaskOptionOpen((prev) => !prev);
   };
@@ -58,105 +77,117 @@ export default function ToDoModal({
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      className="h-[708px] w-[calc(100vw-48px)] md:h-[770px] md:w-[calc(100vw-64px)] lg:w-[730px]"
-    >
-      <div className="h-full p-3 md:px-[28px] md:py-[32px]">
-        <div className="flex items-center justify-between">
-          <h1 className="text-xl font-bold md:text-2xl">{props.props.title}</h1>
-          <div className="flex gap-x-6">
-            <button
-              type="button"
-              className="relative size-6 md:size-8"
-              onClick={handleTaskOptionToggle}
-            >
-              <Image
-                src="/icons/icon_three_point.svg"
-                alt="세 점 아이콘"
-                fill
-              />
-              {isTaskOptionOpen && (
-                <TaskOption>
-                  <li className="flex h-[30px] w-full items-center justify-center rounded-md hover:bg-violet-primary/10 md:h-[32px]">
-                    수정하기
-                  </li>
-                  {/* eslint-disable-next-line */}
-                  <li
-                    className="flex h-[30px] w-full items-center justify-center rounded-md hover:bg-violet-primary/10 md:h-[32px]"
-                    onClick={() => handleDeleteTask(props.props.id)}
-                  >
-                    삭제하기
-                  </li>
-                </TaskOption>
-              )}
-            </button>
-            <button
-              type="button"
-              className="relative size-6 cursor-pointer md:size-8"
-            >
-              <Image
-                src="/icons/icon_close.svg"
-                alt="닫기 아이콘"
-                onClick={onClose}
-                fill
-              />
-            </button>
-          </div>
-        </div>
-        <div className="mt-4 flex h-full flex-col md:flex-row-reverse">
-          <div className="flex w-full items-center justify-between rounded-lg border p-4 md:h-[155px] md:w-[180px] md:flex-col lg:w-[200px]">
-            <div className="flex w-full flex-col">
-              <p className="text-[10px] font-semibold md:text-xs">담당자</p>
-              <div className="flex items-center gap-x-2">
-                <div className="relative size-[26px] md:size-[34px]">
-                  <ProfileImage
-                    profileImageUrl={props.props.assignee.profileImageUrl}
-                    nickname={props.props.assignee.nickname}
-                    id={props.props.assignee.id}
-                    size="24px"
-                  />
-                </div>
-                <p>{props.props.assignee.nickname}</p>
-              </div>
-            </div>
-            <div className="flex-flex-col w-full">
-              <p className="text-[10px] font-semibold md:text-xs">마감일</p>
-              <p className="text-xs md:text-sm">
-                {formatDate(new Date(props.props.dueDate))}
-              </p>
-            </div>
-          </div>
-          <div className="mb-[44px] mt-4 w-full overflow-y-auto md:mt-0">
-            <div className="h-full w-full md:pr-6">
-              <div className="flex h-5 items-center gap-x-5">
-                <ColumnTag title={columnTitle} />
-                {props.props.tags?.length > 0 && (
-                  <div className="h-full border-l" />
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        className="h-[708px] w-[calc(100vw-48px)] md:h-[770px] md:w-[calc(100vw-64px)] lg:w-[730px]"
+      >
+        <div className="h-full p-3 md:px-[28px] md:py-[32px]">
+          <div className="flex items-center justify-between">
+            <h1 className="text-xl font-bold md:text-2xl">
+              {props.props.title}
+            </h1>
+            <div className="flex gap-x-6">
+              <button
+                type="button"
+                className="relative size-6 md:size-8"
+                onClick={handleTaskOptionToggle}
+              >
+                <Image
+                  src="/icons/icon_three_point.svg"
+                  alt="세 점 아이콘"
+                  fill
+                />
+                {isTaskOptionOpen && (
+                  <TaskOption>
+                    <li
+                      className="flex h-[30px] w-full items-center justify-center rounded-md hover:bg-violet-primary/10 md:h-[32px]"
+                      onClick={handleEditTask}
+                    >
+                      수정하기
+                    </li>
+                    {/* eslint-disable-next-line */}
+                    <li
+                      className="flex h-[30px] w-full items-center justify-center rounded-md hover:bg-violet-primary/10 md:h-[32px]"
+                      onClick={() => handleDeleteTask(props.props.id)}
+                    >
+                      삭제하기
+                    </li>
+                  </TaskOption>
                 )}
-                {props.props.tags?.map((tag: string) => (
-                  <Tag key={tag}>{tag}</Tag>
-                ))}
-              </div>
-              <p className="my-4">{props.props.description}</p>
-
-              {props.props.imageUrl && (
-                <div className="relative size-fit h-[300px] w-full md:h-[400px]">
-                  <Image
-                    src={props.props.imageUrl!}
-                    alt="modal-image"
-                    layout="fill"
-                    objectFit="cover"
-                    className="rounded-md"
-                  />
+              </button>
+              <button
+                type="button"
+                className="relative size-6 cursor-pointer md:size-8"
+              >
+                <Image
+                  src="/icons/icon_close.svg"
+                  alt="닫기 아이콘"
+                  onClick={onClose}
+                  fill
+                />
+              </button>
+            </div>
+          </div>
+          <div className="mt-4 flex h-full flex-col md:flex-row-reverse">
+            <div className="flex w-full items-center justify-between rounded-lg border p-4 md:h-[155px] md:w-[180px] md:flex-col lg:w-[200px]">
+              <div className="flex w-full flex-col">
+                <p className="text-[10px] font-semibold md:text-xs">담당자</p>
+                <div className="flex items-center gap-x-2">
+                  <div className="relative size-[26px] md:size-[34px]">
+                    <ProfileImage
+                      profileImageUrl={props.props.assignee.profileImageUrl}
+                      nickname={props.props.assignee.nickname}
+                      id={props.props.assignee.id}
+                      size="24px"
+                    />
+                  </div>
+                  <p>{props.props.assignee.nickname}</p>
                 </div>
-              )}
-              <TodoModalComment />
+              </div>
+              <div className="flex-flex-col w-full">
+                <p className="text-[10px] font-semibold md:text-xs">마감일</p>
+                <p className="text-xs md:text-sm">
+                  {formatDate(new Date(props.props.dueDate))}
+                </p>
+              </div>
+            </div>
+            <div className="mb-[44px] mt-4 w-full overflow-y-auto md:mt-0">
+              <div className="h-full w-full md:pr-6">
+                <div className="flex h-5 items-center gap-x-5">
+                  <ColumnTag title={columnTitle} />
+                  {props.props.tags?.length > 0 && (
+                    <div className="h-full border-l" />
+                  )}
+                  {props.props.tags?.map((tag: string) => (
+                    <Tag key={tag}>{tag}</Tag>
+                  ))}
+                </div>
+                <p className="my-4">{props.props.description}</p>
+
+                {props.props.imageUrl && (
+                  <div className="relative size-fit h-[300px] w-full md:h-[400px]">
+                    <Image
+                      src={props.props.imageUrl!}
+                      alt="modal-image"
+                      layout="fill"
+                      objectFit="cover"
+                      className="rounded-md"
+                    />
+                  </div>
+                )}
+                <TodoModalComment />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+      <AddToDoModal
+        isOpen={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
+        columnId={props.props.columnId}
+      />
+    </>
   );
 }

--- a/app/(dashboard)/_components/todo-modal.tsx
+++ b/app/(dashboard)/_components/todo-modal.tsx
@@ -20,6 +20,16 @@ import TodoModalComment from './todo-modal-comment';
 
 /* eslint-disable */
 
+/* eslint-disable */
+
+/* eslint-disable */
+
+/* eslint-disable */
+
+/* eslint-disable */
+
+/* eslint-disable */
+
 export default function ToDoModal({
   isOpen,
   onClose,
@@ -128,17 +138,20 @@ export default function ToDoModal({
             <div className="flex w-full items-center justify-between rounded-lg border p-4 md:h-[155px] md:w-[180px] md:flex-col lg:w-[200px]">
               <div className="flex w-full flex-col">
                 <p className="text-[10px] font-semibold md:text-xs">담당자</p>
-                <div className="flex items-center gap-x-2">
-                  <div className="relative size-[26px] md:size-[34px]">
-                    <ProfileImage
-                      profileImageUrl={props.props.assignee.profileImageUrl}
-                      nickname={props.props.assignee.nickname}
-                      id={props.props.assignee.id}
-                      size="24px"
-                    />
+                {/* NOTE - 담당자 없을 때도 있습니다 */}
+                {props.props.assignee && (
+                  <div className="flex items-center gap-x-2">
+                    <div className="relative size-[26px] md:size-[34px]">
+                      <ProfileImage
+                        profileImageUrl={props.props.assignee.profileImageUrl}
+                        nickname={props.props.assignee.nickname}
+                        id={props.props.assignee.id}
+                        size="24px"
+                      />
+                    </div>
+                    <p>{props.props.assignee.nickname}</p>
                   </div>
-                  <p>{props.props.assignee.nickname}</p>
-                </div>
+                )}
               </div>
               <div className="flex-flex-col w-full">
                 <p className="text-[10px] font-semibold md:text-xs">마감일</p>

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-due-date-input.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-due-date-input.tsx
@@ -1,12 +1,20 @@
 import calendar from '@/public/icons/icon_calendar.svg';
 import { format as formatDate } from 'date-fns';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { useFormContext } from 'react-hook-form';
 
-export default function AddDueDateInput() {
+interface AddDueDateInputProps {
+  dueDateValue?: string | null;
+  isEdit: boolean;
+}
+
+export default function AddDueDateInput({
+  dueDateValue,
+  isEdit,
+}: AddDueDateInputProps) {
   const { register, setValue } = useFormContext();
   // NOTE - 초기값 null : 어떤 날짜도 선택되지 않았음 표시
   const [dateValue, setDateValue] = useState<Date | null>(null);
@@ -25,6 +33,14 @@ export default function AddDueDateInput() {
       setDateValue(date);
     }
   };
+
+  useEffect(() => {
+    if (dueDateValue && isEdit) {
+      setDateValue(new Date(dueDateValue));
+    } else {
+      setDateValue(null);
+    }
+  }, [dueDateValue, isEdit]);
 
   return (
     <div className="flex flex-col gap-y-2">

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -35,7 +35,7 @@ export default function AddToDoModal({
     resolver: yupResolver(createTodoSchema),
     mode: 'onChange',
     defaultValues: {
-      assigneeUserId: toDoValue?.assignee.id || undefined,
+      assigneeUserId: toDoValue?.assignee?.id || undefined,
       title: toDoValue?.title || '',
       description: toDoValue?.description || '',
       dueDate: toDoValue?.dueDate || undefined,
@@ -70,7 +70,7 @@ export default function AddToDoModal({
     isValid ||
     JSON.stringify(watchFields) !==
       JSON.stringify({
-        assigneeUserId: toDoValue?.assignee.id || undefined,
+        assigneeUserId: toDoValue?.assignee?.id || undefined,
         title: toDoValue?.title || '',
         description: toDoValue?.description || '',
         dueDate: toDoValue?.dueDate || undefined,
@@ -81,11 +81,14 @@ export default function AddToDoModal({
     const { assigneeUserId, title, description } = data;
 
     const formData = new FormData();
-    formData.append('assigneeUserId', assigneeUserId.toString());
     formData.append('dashboardId', id.toString());
     formData.append('columnId', column.toString());
     formData.append('title', title);
     formData.append('description', description);
+
+    if (assigneeUserId) {
+      formData.append('assigneeUserId', assigneeUserId.toString());
+    }
 
     if (tags.length > 0) {
       formData.append('tags', JSON.stringify(tags));
@@ -124,7 +127,7 @@ export default function AddToDoModal({
     if (toDoValue && !isEdit) {
       setIsEdit(true);
       reset({
-        assigneeUserId: toDoValue.assignee.id,
+        assigneeUserId: toDoValue.assignee?.id,
         title: toDoValue.title,
         description: toDoValue.description,
         dueDate: toDoValue.dueDate || '',

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -101,9 +101,6 @@ export default function AddToDoModal({
 
     if (isEdit && cardId) {
       try {
-        console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 수정하기 테스트중');
-        console.log('>>>>>>>>>>>>> 보낼 데이터');
-        console.log(data);
         const res = await updateToDoCard(formData, cardId);
         if (res) {
           onClose();

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -15,6 +15,7 @@ import { postToDoCard, updateToDoCard } from '../../action';
 import AddDueDateInput from './add-due-date-input';
 import AddTagInput from './add-tag-input';
 import AssigneeUserDropdown from './assignee-user-dropdown';
+import ColumnDropdown from './column-dropdown';
 
 interface AddToDoModalProps {
   isOpen: boolean;
@@ -51,7 +52,7 @@ export default function AddToDoModal({
     formState: { errors, isValid, isDirty },
   } = methods;
   const [tags, setTags] = useState<string[]>(toDoValue?.tags || []);
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id: string }>(); // 대시보드 id
   const [isEdit, setIsEdit] = useState(false);
 
   // 감시할 필드들을 설정
@@ -151,8 +152,10 @@ export default function AddToDoModal({
           className="flex flex-grow flex-col overflow-hidden px-5 pb-5"
         >
           <div className="flex flex-grow flex-col gap-6 overflow-y-auto overflow-x-hidden">
-            <div className="flex flex-col gap-y-2">
-              <p className="text-base font-medium md:text-lg">담당자</p>
+            <div className="flex flex-col gap-2 md:flex-row">
+              {isEdit && (
+                <ColumnDropdown dashboardId={id} columnId={columnId} />
+              )}
               <AssigneeUserDropdown
                 dashboardId={id}
                 isEdit={isEdit}

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -31,16 +31,18 @@ export default function AddToDoModal({
   toDoValue,
   cardId,
 }: AddToDoModalProps) {
+  const defaultValues = {
+    assigneeUserId: toDoValue?.assignee?.id || undefined,
+    title: toDoValue?.title || '',
+    description: toDoValue?.description || '',
+    dueDate: toDoValue?.dueDate || undefined,
+    imageUrl: toDoValue?.imageUrl || '',
+  };
+
   const methods = useForm<toDoCardValue>({
     resolver: yupResolver(createTodoSchema),
     mode: 'onChange',
-    defaultValues: {
-      assigneeUserId: toDoValue?.assignee?.id || undefined,
-      title: toDoValue?.title || '',
-      description: toDoValue?.description || '',
-      dueDate: toDoValue?.dueDate || undefined,
-      imageUrl: toDoValue?.imageUrl || '',
-    },
+    defaultValues,
   });
   const {
     register,
@@ -48,38 +50,15 @@ export default function AddToDoModal({
     handleSubmit,
     setValue,
     reset,
-    watch,
-    formState: { errors, isValid, isDirty },
+    formState: { errors, isValid },
   } = methods;
   const [tags, setTags] = useState<string[]>(toDoValue?.tags || []);
   const [column, setColumn] = useState(columnId);
   const { id } = useParams<{ id: string }>(); // 대시보드 id
   const [isEdit, setIsEdit] = useState(false);
 
-  // 감시할 필드들을 설정
-  const watchFields = watch([
-    'assigneeUserId',
-    'title',
-    'description',
-    'dueDate',
-    'imageUrl',
-  ]);
-
-  const isFormChanged =
-    isDirty ||
-    isValid ||
-    JSON.stringify(watchFields) !==
-      JSON.stringify({
-        assigneeUserId: toDoValue?.assignee?.id || undefined,
-        title: toDoValue?.title || '',
-        description: toDoValue?.description || '',
-        dueDate: toDoValue?.dueDate || undefined,
-        imageUrl: toDoValue?.imageUrl || null,
-      });
-
   const onSubmit: SubmitHandler<toDoCardValue> = async (data) => {
     const { assigneeUserId, title, description, dueDate, imageUrl } = data;
-
     // NOTE - 필수값
     const jsonObject: { [key: string]: any } = {
       dashboardId: Number(id),
@@ -106,7 +85,6 @@ export default function AddToDoModal({
 
     try {
       if (isEdit && cardId) {
-        console.log('수정하기>>>>>>>>>>>>>>>>>>>>...');
         console.log(jsonObject);
         await updateToDoCard(jsonObject, cardId);
       } else {
@@ -125,13 +103,7 @@ export default function AddToDoModal({
     if (toDoValue && !isEdit) {
       setIsEdit(true);
       setTags(toDoValue.tags);
-      reset({
-        assigneeUserId: toDoValue.assignee?.id,
-        title: toDoValue.title,
-        description: toDoValue.description,
-        dueDate: toDoValue.dueDate || '',
-        imageUrl: toDoValue?.imageUrl || null,
-      });
+      reset(defaultValues);
     }
   }, [isEdit, reset, toDoValue]);
 
@@ -226,7 +198,6 @@ export default function AddToDoModal({
               <button
                 type="submit"
                 className="h-[42px] w-full rounded bg-violet-primary text-center text-sm font-medium text-white disabled:bg-gray-400 md:w-[120px] md:text-base"
-                disabled={!isFormChanged}
               >
                 수정
               </button>

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -43,6 +43,7 @@ export default function AddToDoModal({
   });
   const {
     register,
+    unregister,
     handleSubmit,
     setValue,
     reset,
@@ -71,7 +72,7 @@ export default function AddToDoModal({
         title: toDoValue?.title || '',
         description: toDoValue?.description || '',
         dueDate: toDoValue?.dueDate || undefined,
-        imageUrl: toDoValue?.imageUrl || '',
+        imageUrl: toDoValue?.imageUrl || null,
       });
 
   const onSubmit: SubmitHandler<toDoCardValue> = async (data) => {
@@ -98,10 +99,9 @@ export default function AddToDoModal({
 
     if (isEdit && cardId) {
       try {
-        console.log('>>>>>>>>>>>>> 수정하기 테스트중');
+        console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 수정하기 테스트중');
+        console.log('>>>>>>>>>>>>> 보낼 데이터');
         console.log(data);
-        console.log(tags);
-        console.log(toDoValue?.imageUrl);
         const res = await updateToDoCard(formData, cardId);
         if (res) {
           onClose();
@@ -129,7 +129,7 @@ export default function AddToDoModal({
         title: toDoValue.title,
         description: toDoValue.description,
         dueDate: toDoValue.dueDate || '',
-        imageUrl: toDoValue.imageUrl || '',
+        imageUrl: toDoValue?.imageUrl || null,
       });
     }
   }, [isEdit, reset, toDoValue]);
@@ -196,6 +196,7 @@ export default function AddToDoModal({
                 id="imageUrl"
                 setValue={setValue}
                 imageUrlValue={toDoValue?.imageUrl}
+                unregister={unregister}
               />
             </div>
           </div>

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -52,6 +52,7 @@ export default function AddToDoModal({
     formState: { errors, isValid, isDirty },
   } = methods;
   const [tags, setTags] = useState<string[]>(toDoValue?.tags || []);
+  const [column, setColumn] = useState(columnId);
   const { id } = useParams<{ id: string }>(); // 대시보드 id
   const [isEdit, setIsEdit] = useState(false);
 
@@ -82,7 +83,7 @@ export default function AddToDoModal({
     const formData = new FormData();
     formData.append('assigneeUserId', assigneeUserId.toString());
     formData.append('dashboardId', id.toString());
-    formData.append('columnId', columnId.toString());
+    formData.append('columnId', column.toString());
     formData.append('title', title);
     formData.append('description', description);
 
@@ -154,7 +155,11 @@ export default function AddToDoModal({
           <div className="flex flex-grow flex-col gap-6 overflow-y-auto overflow-x-hidden">
             <div className="flex flex-col gap-2 md:flex-row">
               {isEdit && (
-                <ColumnDropdown dashboardId={id} columnId={columnId} />
+                <ColumnDropdown
+                  dashboardId={id}
+                  columnId={column}
+                  setColumn={setColumn}
+                />
               )}
               <AssigneeUserDropdown
                 dashboardId={id}

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-title-input.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-title-input.tsx
@@ -1,0 +1,24 @@
+import { useFormContext } from 'react-hook-form';
+
+export default function AddToDoTitleInput() {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
+  return (
+    <div className="mb-4 flex flex-col gap-y-2">
+      <label htmlFor="title" className="text-base font-medium md:text-lg">
+        제목
+      </label>
+      <input
+        type="text"
+        placeholder="제목을 입력해 주세요"
+        className="h-[50px] rounded-lg border border-gray-300 p-4 placeholder:text-gray-400"
+        {...register('title')}
+      />
+      {errors.title && typeof errors.title.message === 'string' && (
+        <p className="text-red-500">{errors.title.message}</p>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -10,13 +10,20 @@ import { useFormContext } from 'react-hook-form';
 
 interface AssigneeUserDropdownProps {
   dashboardId: string;
+  isEdit?: boolean;
+  assigneeUserId?: number;
 }
 
 export default function AssigneeUserDropdown({
   dashboardId,
+  isEdit,
+  assigneeUserId,
 }: AssigneeUserDropdownProps) {
   const token = getCookie('token');
   const [members, setMembers] = useState<DashboardMembers[]>([]);
+  const [selectedMember, setSelectedMember] = useState<DashboardMembers | null>(
+    null
+  );
 
   const { register, setValue } = useFormContext();
 
@@ -39,6 +46,13 @@ export default function AssigneeUserDropdown({
     if (res.ok) {
       const data = await res.json();
       setMembers(data.members);
+      // NOTE - 수정하기인 경우 기본값
+      if (isEdit && assigneeUserId) {
+        const assignedMember = data.members.find(
+          (member: DashboardMembers) => member.userId === assigneeUserId
+        );
+        setSelectedMember(assignedMember || null);
+      }
     } else {
       console.error('Failed to fetch members:', res.statusText);
     }
@@ -57,7 +71,25 @@ export default function AssigneeUserDropdown({
   return (
     <div className="md:w-1/2">
       <Dropdown>
-        <Dropdown.Toggle>이름을 입력해 주세요</Dropdown.Toggle>
+        <Dropdown.Toggle>
+          {selectedMember ? (
+            <div className="flex h-full w-full cursor-pointer items-center gap-2">
+              <ProfileImage
+                profileImageUrl={selectedMember.profileImageUrl}
+                nickname={selectedMember.nickname}
+                id={selectedMember.userId}
+                size="26px"
+              />
+              <p className="text-sm font-normal text-gray-700">
+                {selectedMember.nickname}
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm font-normal text-gray-400">
+              이름을 입력해 주세요
+            </p>
+          )}
+        </Dropdown.Toggle>
         <Dropdown.List>
           {members.map((member) => (
             <Dropdown.Item key={member.userId}>

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -55,14 +55,14 @@ export default function AssigneeUserDropdown({
   }, [dashboardId]);
 
   return (
-    <div>
+    <div className="md:w-1/2">
       <Dropdown>
         <Dropdown.Toggle>이름을 입력해 주세요</Dropdown.Toggle>
         <Dropdown.List>
           {members.map((member) => (
             <Dropdown.Item key={member.userId}>
               <div
-                className="flex h-full w-full cursor-pointer items-center gap-2 md:w-[50%]"
+                className="flex h-full w-full cursor-pointer items-center gap-2"
                 onClick={() => handleItemClick(member.userId)}
                 tabIndex={0}
                 role="button"

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -69,7 +69,8 @@ export default function AssigneeUserDropdown({
   }, [dashboardId]);
 
   return (
-    <div className="md:w-1/2">
+    <div className="flex flex-col gap-y-2 md:w-1/2">
+      <p className="text-base font-medium md:text-lg">담당자</p>
       <Dropdown>
         <Dropdown.Toggle>
           {selectedMember ? (

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -62,7 +62,7 @@ export default function AssigneeUserDropdown({
           {members.map((member) => (
             <Dropdown.Item key={member.userId}>
               <div
-                className="flex h-full w-full cursor-pointer items-center gap-2"
+                className="flex h-full w-full cursor-pointer items-center gap-2 md:w-[50%]"
                 onClick={() => handleItemClick(member.userId)}
                 tabIndex={0}
                 role="button"

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable */
+'use client';
+
+import ColumnTag from '@/app/components/column-tag';
+import Dropdown from '@/app/components/dropdown';
+import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { ColumnData } from '@/types/card';
+import { getCookie } from 'cookies-next';
+import { useEffect, useState } from 'react';
+
+/* eslint-disable */
+
+/* eslint-disable */
+
+interface ColumnDropdownProps {
+  dashboardId: string;
+  columnId: number;
+}
+
+export default function ColumnDropdown({
+  dashboardId,
+  columnId,
+}: ColumnDropdownProps) {
+  const [columns, setColumns] = useState<ColumnData[]>([]);
+  const token = getCookie('token');
+
+  async function getColumns() {
+    const res = await fetch(
+      `${TEAM_BASE_URL}/columns?dashboardId=${dashboardId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    const { data } = await res.json();
+    setColumns(data);
+  }
+
+  const handleItemClick = (id: number) => {
+    console.log('선택된 컬럼 ID:' + id);
+  };
+
+  useEffect(() => {
+    getColumns();
+  }, [dashboardId]);
+
+  return (
+    <div className="flex flex-col gap-y-2 md:w-1/2">
+      <p className="text-base font-medium md:text-lg">상태</p>
+      <Dropdown>
+        <Dropdown.Toggle>상태</Dropdown.Toggle>
+        <Dropdown.List>
+          {columns.map((column) => (
+            <Dropdown.Item key={column.id}>
+              <div
+                className="flex h-full w-full cursor-pointer items-center"
+                onClick={() => handleItemClick(column.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleItemClick(column.id);
+                  }
+                }}
+              >
+                <ColumnTag title={column.title} />
+              </div>
+            </Dropdown.Item>
+          ))}
+        </Dropdown.List>
+      </Dropdown>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
@@ -15,11 +15,13 @@ import { useEffect, useState } from 'react';
 interface ColumnDropdownProps {
   dashboardId: string;
   columnId: number;
+  setColumn: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function ColumnDropdown({
   dashboardId,
   columnId,
+  setColumn,
 }: ColumnDropdownProps) {
   const [columns, setColumns] = useState<ColumnData[]>([]);
   const token = getCookie('token');
@@ -41,18 +43,27 @@ export default function ColumnDropdown({
   }
 
   const handleItemClick = (id: number) => {
-    console.log('선택된 컬럼 ID:' + id);
+    setColumn(id);
   };
 
   useEffect(() => {
     getColumns();
-  }, [dashboardId]);
+  }, [getColumns]);
 
   return (
     <div className="flex flex-col gap-y-2 md:w-1/2">
       <p className="text-base font-medium md:text-lg">상태</p>
       <Dropdown>
-        <Dropdown.Toggle>상태</Dropdown.Toggle>
+        <Dropdown.Toggle>
+          <div className="flex h-full w-full cursor-pointer items-center">
+            <ColumnTag
+              title={
+                columns.find((column) => column.id === columnId)?.title ??
+                'Default Title'
+              }
+            />
+          </div>
+        </Dropdown.Toggle>
         <Dropdown.List>
           {columns.map((column) => (
             <Dropdown.Item key={column.id}>

--- a/app/(dashboard)/dashboard/[id]/action.ts
+++ b/app/(dashboard)/dashboard/[id]/action.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
 // NOTE - 이미지 업로드
@@ -117,7 +118,7 @@ export async function updateToDoCard(formData: FormData, cardId: number) {
 
   if (response.status === 200) {
     const data = await response.json();
-    console.log('카드 수정 성공:', data);
+    revalidatePath(`/dashboard/${formData.get('dashboardId')}`);
     return data;
   }
   const errorData = await response.json();

--- a/app/(dashboard)/dashboard/[id]/action.ts
+++ b/app/(dashboard)/dashboard/[id]/action.ts
@@ -82,12 +82,11 @@ export async function updateToDoCard(formData: FormData, cardId: number) {
   let imageUrl;
   // NOTE - 이미지가 파일 객체로 제공될 경우에만 이미지 업로드 처리(이미지를 추가하거나 변경하는 경우)
   const imageUrlValue = formData.get('imageUrl');
-  if (typeof imageUrlValue === 'object' && imageUrlValue instanceof File) {
+  if (imageUrlValue instanceof File) {
     const imageFile = imageUrlValue as File;
     const columnId = parseInt(formData.get('columnId') as string, 10);
     imageUrl = await postToDoCardImage(imageFile, columnId);
     formData.set('imageUrl', imageUrl); // 업로드된 이미지 URL로 formData 업데이트
-    console.log(`이미지 url 생성 : ${imageUrl}`);
   }
 
   const token = cookies().get('token')?.value;

--- a/app/components/dropdown.tsx
+++ b/app/components/dropdown.tsx
@@ -15,6 +15,10 @@ import {
 
 /* eslint-disable */
 
+/* eslint-disable */
+
+/* eslint-disable */
+
 interface DropdownContextType {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -25,17 +25,12 @@ export default function ImageInputField({
     }
   };
 
+  // TODO - 수정하기에서 이미지 x 누른 후 그대로 수정하면 오류남
   const handleImageDelete = () => {
     unregister(id);
     setSelectedImage(null);
     setInitialImage(null);
   };
-
-  // useEffect(() => {
-  //   if (imageUrlValue) {
-  //     setInitialImage(imageUrlValue);
-  //   }
-  // }, [imageUrlValue]);
 
   return (
     <div>

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -1,13 +1,15 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export default function ImageInputField({
   id,
   setValue,
   imageUrlValue,
+  unregister,
 }: {
   id: string;
   setValue: any;
+  unregister?: any;
   imageUrlValue?: string | null;
 }) {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
@@ -24,15 +26,16 @@ export default function ImageInputField({
   };
 
   const handleImageDelete = () => {
+    unregister(id);
     setSelectedImage(null);
-    setValue(id, null);
+    setInitialImage(null);
   };
 
-  useEffect(() => {
-    if (imageUrlValue) {
-      setInitialImage(imageUrlValue);
-    }
-  }, [imageUrlValue]);
+  // useEffect(() => {
+  //   if (imageUrlValue) {
+  //     setInitialImage(imageUrlValue);
+  //   }
+  // }, [imageUrlValue]);
 
   return (
     <div>

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -1,14 +1,19 @@
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function ImageInputField({
   id,
   setValue,
+  imageUrlValue,
 }: {
   id: string;
   setValue: any;
+  imageUrlValue?: string | null;
 }) {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
+  const [initialImage, setInitialImage] = useState<string | null>(
+    imageUrlValue || null
+  );
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -23,12 +28,22 @@ export default function ImageInputField({
     setValue(id, null);
   };
 
+  useEffect(() => {
+    if (imageUrlValue) {
+      setInitialImage(imageUrlValue);
+    }
+  }, [imageUrlValue]);
+
   return (
     <div>
-      {selectedImage ? (
+      {initialImage || selectedImage ? (
         <div className="relative size-[100px] md:size-[182px]">
           <Image
-            src={URL.createObjectURL(selectedImage)}
+            src={
+              selectedImage
+                ? URL.createObjectURL(selectedImage)
+                : (initialImage as string)
+            }
             alt="Selected Image"
             sizes="(min-width: 768px) 100vw"
             fill

--- a/lib/schemas/createToDo.ts
+++ b/lib/schemas/createToDo.ts
@@ -2,7 +2,8 @@ import * as yup from 'yup';
 
 // 사용자 정의 유효성 검사 함수
 const imageFileValidation = (value: any) => {
-  if (!value) return true; // 파일이 없는 경우 유효성 검사 통과
+  // 파일이 없거나 문자열인 경우 유효성 검사 통과
+  if (!value || typeof value === 'string') return true;
 
   // File 객체인지 확인
   if (value instanceof File) {

--- a/lib/schemas/createToDo.ts
+++ b/lib/schemas/createToDo.ts
@@ -15,7 +15,7 @@ const imageFileValidation = (value: any) => {
 };
 
 const createTodoSchema = yup.object().shape({
-  assigneeUserId: yup.number().required('담당자를 선택해 주세요.'),
+  assigneeUserId: yup.number(),
   title: yup
     .string()
     .required('제목을 입력해 주세요')

--- a/types/card.ts
+++ b/types/card.ts
@@ -3,9 +3,9 @@ export interface CardData {
   title: string;
   description: string;
   tags: string[];
-  dueDate: string;
+  dueDate: string | null;
   assignee: Assignee;
-  imageUrl: string;
+  imageUrl: string | null;
   teamId: string;
   columnId: number;
   createdAt: Date;
@@ -13,7 +13,7 @@ export interface CardData {
 }
 
 export interface Assignee {
-  profileImageUrl: string;
+  profileImageUrl: string | null;
   nickname: string;
   id: number;
 }

--- a/types/card.ts
+++ b/types/card.ts
@@ -4,7 +4,7 @@ export interface CardData {
   description: string;
   tags: string[];
   dueDate: string | null;
-  assignee: Assignee;
+  assignee: Assignee | null;
   imageUrl: string | null;
   teamId: string;
   columnId: number;

--- a/types/toDoCard.ts
+++ b/types/toDoCard.ts
@@ -1,5 +1,5 @@
 export interface toDoCardValue {
-  assigneeUserId: number;
+  assigneeUserId?: number;
   title: string;
   description: string;
   dueDate?: string;

--- a/types/toDoCard.ts
+++ b/types/toDoCard.ts
@@ -7,3 +7,14 @@ export interface toDoCardValue {
 }
 
 // TODO - imageUrl 타입 any 변경
+
+export interface PostCardValue {
+  dashboardId: number;
+  columnId: number;
+  title: string;
+  description: string;
+  assigneeUserId?: number;
+  tags?: string[];
+  dueDate?: string;
+  imageUrl?: any;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#124

## 📝작업 내용
죽겠네요 ... 리액트 훅 폼이랑 yup 사용이 참 어려운 거 같읍니다 .. 
formdata 데이터 변환 로직이 깔끔하지 않아서 기존 생성 로직도 변경했습니다. 

상태,제목,담당자,내용,마감일자,태그,이미지를 변경할 수 있습니다
입력 값에 따른 버튼 활성화 비활성화, 수정 성공,실패 후 토스트 등은 따로 이슈 생성해서 하겠습니다.  
지금 버그는 수정하기에서 기존 이미지가 있었을 경우 x 버튼 눌러 이미지 삭제한 후에 별도의 이미지를 다시 추가하지 않고 수정하기 누르면 오류 뜹니다 ㅎ하하 그냥 이미지가 없는 경우는 잘 돼요 

이게 공통 컴포넌트라 우선은 냅둘게요  ... 

제가 여러 번 테스트 많이 해보긴 했는데 놓친 부분 있을 수도 있을 거 같아서 
여러 번 테스트 해주시면 감사하겠읍니다.버그 발견하시면 알려주세요!! 
