### PR TITLE
🐛 fix: 대시보드 페이지네이션 버그 수정

### DIFF
--- a/app/(dashboard)/mydashboard/_components/dashboard-list.tsx
+++ b/app/(dashboard)/mydashboard/_components/dashboard-list.tsx
@@ -3,55 +3,11 @@
 import PageButton from '@/app/components/pagination/page-button';
 import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
 import { DashboardDetail } from '@/types/dashboard';
+import makeDashboardArr from '@/utils/makeDashboardResponse';
 import { getCookie } from 'cookies-next';
 import { useEffect, useState } from 'react';
 
 import DashboardCard from './dashboard-card';
-
-const token = getCookie('token');
-
-// NOTE: 대시보드 중복 제거 후 6개로 맞추는 함수
-async function makeDashboardArr(
-  arr: DashboardDetail[],
-  page: number,
-  size: number
-): Promise<DashboardDetail[]> {
-  const url = `${TEAM_BASE_URL}/dashboards?navigationMethod=pagination&page=${page + 1}&size=${size}`;
-
-  async function reFetch() {
-    const res = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    const data = await res.json();
-    const { dashboards } = data;
-    return dashboards;
-  }
-
-  const fetchArr: DashboardDetail[] = await reFetch();
-
-  const checkDashboard: DashboardDetail[] = fetchArr.reduce(
-    (acc: DashboardDetail[], cur: DashboardDetail) => {
-      if (acc.findIndex(({ id }) => id === cur.id) === -1) {
-        acc.push(cur);
-      }
-      return acc;
-    },
-    []
-  );
-
-  arr.push(...checkDashboard);
-
-  if (arr.length < 6) {
-    makeDashboardArr(arr, page + 1, size - arr.length);
-  }
-
-  return arr;
-}
 
 interface DashboardListProps {
   initialData: DashboardDetail[];
@@ -65,6 +21,8 @@ export default function DashboardList({
   const [page, setPage] = useState(1);
   const [dashboardList, setDashboardList] =
     useState<DashboardDetail[]>(initialData);
+
+  const token = getCookie('token');
 
   async function getData() {
     const url = `${TEAM_BASE_URL}/dashboards?navigationMethod=pagination&page=${page}&size=6`;
@@ -93,7 +51,12 @@ export default function DashboardList({
     // NOTE: 6개 이하일 경우(=중복 데이터 존재) 함수 호출
     if (checkDashboard.length < 6) {
       setDashboardList(
-        await makeDashboardArr(checkDashboard, page, 6 - checkDashboard.length)
+        await makeDashboardArr(
+          checkDashboard,
+          page,
+          6 - checkDashboard.length,
+          token
+        )
       );
       return;
     }

--- a/app/components/sidebar/sidebar-dashboard-list.tsx
+++ b/app/components/sidebar/sidebar-dashboard-list.tsx
@@ -48,7 +48,7 @@ export default function SidebarDashboardList({
       []
     );
 
-    // NOTE: 6개 이하일 경우(=중복 데이터 존재) 함수 호출
+    // NOTE: 10개 이하일 경우(=중복 데이터 존재) 함수 호출
     if (checkDashboard.length < 10) {
       setDashboardList(
         await makeDashboardArr(

--- a/app/components/sidebar/sidebar-dashboard.tsx
+++ b/app/components/sidebar/sidebar-dashboard.tsx
@@ -10,7 +10,9 @@ export default async function SidebarDashboard() {
   });
 
   const data = await getFetcher(`/dashboards?${params.toString()}`);
-  const { dashboards } = data;
+  const { dashboards, totalCount } = data;
 
-  return <SidebarDashboardList initialData={dashboards} />;
+  const lastPage = Math.ceil(totalCount / 6);
+
+  return <SidebarDashboardList initialData={dashboards} lastPage={lastPage} />;
 }

--- a/utils/makeDashboardResponse.ts
+++ b/utils/makeDashboardResponse.ts
@@ -1,0 +1,46 @@
+import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
+import { DashboardDetail } from '@/types/dashboard';
+
+// NOTE: 대시보드 중복 제거 후 6개로 맞추는 함수
+export default async function makeDashboardArr(
+  arr: DashboardDetail[],
+  page: number,
+  size: number,
+  token?: string
+): Promise<DashboardDetail[]> {
+  const url = `${TEAM_BASE_URL}/dashboards?navigationMethod=pagination&page=${page + 1}&size=${size}`;
+
+  async function reFetch() {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await res.json();
+    const { dashboards } = data;
+    return dashboards;
+  }
+
+  const fetchArr: DashboardDetail[] = await reFetch();
+
+  const checkDashboard: DashboardDetail[] = fetchArr.reduce(
+    (acc: DashboardDetail[], cur: DashboardDetail) => {
+      if (acc.findIndex(({ id }) => id === cur.id) === -1) {
+        acc.push(cur);
+      }
+      return acc;
+    },
+    []
+  );
+
+  arr.push(...checkDashboard);
+
+  if (arr.length < 6) {
+    makeDashboardArr(arr, page + 1, size - arr.length, token);
+  }
+
+  return arr;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#128

## 📝작업 내용

- 중복 초대가 가능한 기능때문에 이슈 발생
  - 서버측에서 하나의 대시보드에 동일한 유저 중복 초대가 가능하기 때문에 수락도 여러번 가능하게 됨
  - 유저가 수락한 대시보드에 동일한 id를 가진 대시보드 데이터가 추가됨
  - 받아온 데이터를 매핑하면 중복 id로 인해 대시보드 컬럼이 정한 갯수 이상이 패칭되는 문제 발생
-  위를 해결하기 위해 데이터의 중복을 제거하고 정한 갯수 이내로 데이터를 fetch 하여 추가하는 util 함수를 구현했습니다.

## 💬리뷰 요구사항(선택)
- 굳이 그랬냐고 묻지 말아주세요 하고 싶었으니까요 🥹