### PR TITLE
✨feat: #143 대시보드 수정 버튼 비활성화 처리 

### DIFF
--- a/app/(dashboard)/_components/todo-modal.tsx
+++ b/app/(dashboard)/_components/todo-modal.tsx
@@ -34,6 +34,10 @@ import TodoModalComment from './todo-modal-comment';
 
 /* eslint-disable */
 
+/* eslint-disable */
+
+/* eslint-disable */
+
 export default function ToDoModal({
   isOpen,
   onClose,
@@ -200,7 +204,7 @@ export default function ToDoModal({
       <AddToDoModal
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
-        columnId={props.props.columnId}
+        columnIdProp={props.props.columnId}
         toDoValue={props.props}
         cardId={props.props.id}
       />

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-due-date-input.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-due-date-input.tsx
@@ -24,9 +24,9 @@ export default function AddDueDateInput({
   const handleDateChange = (date: Date | null) => {
     if (date) {
       const formattedDate = formatDate(date, 'yyyy-MM-dd HH:mm');
-      setValue('dueDate', formattedDate);
+      setValue('dueDate', formattedDate, { shouldDirty: true });
     } else {
-      setValue('dueDate', '');
+      setValue('dueDate', '', { shouldDirty: true });
     }
     if (date !== dateValue) {
       // 상태가 바뀌었을 때만 업데이트

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-tag-input.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-tag-input.tsx
@@ -4,15 +4,21 @@ import { KeyboardEvent } from 'react';
 interface AddTagInputProps {
   tags: string[];
   setTags: React.Dispatch<React.SetStateAction<string[]>>;
+  setIsChange: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function AddTagInput({ tags, setTags }: AddTagInputProps) {
+export default function AddTagInput({
+  tags,
+  setTags,
+  setIsChange,
+}: AddTagInputProps) {
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
       e.preventDefault();
       const value = (e.target as HTMLInputElement).value.trim();
       if (value && !tags.includes(value)) {
         setTags([...tags, value]);
+        setIsChange(true);
         (e.target as HTMLInputElement).value = '';
       } else {
         // NOTE - 같은 값 입력하는 경우
@@ -25,6 +31,7 @@ export default function AddTagInput({ tags, setTags }: AddTagInputProps) {
     const updatedTags = [...tags];
     updatedTags.splice(index, 1);
     setTags(updatedTags);
+    setIsChange(true);
   }
 
   return (

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-tag-input.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-tag-input.tsx
@@ -14,6 +14,9 @@ export default function AddTagInput({ tags, setTags }: AddTagInputProps) {
       if (value && !tags.includes(value)) {
         setTags([...tags, value]);
         (e.target as HTMLInputElement).value = '';
+      } else {
+        // NOTE - 같은 값 입력하는 경우
+        (e.target as HTMLInputElement).value = '';
       }
     }
   }

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-button.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-button.tsx
@@ -29,7 +29,7 @@ export default function AddToDoButton({ columnId }: AddToDoButtonProps) {
         </div>
       </button>
       <AddToDoModal
-        columnId={columnId}
+        columnIdProp={columnId}
         isOpen={isModalOpen}
         onClose={handleCloseModal}
       />

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -32,7 +32,7 @@ export default function AddToDoModal({
   cardId,
 }: AddToDoModalProps) {
   const defaultValues = {
-    assigneeUserId: toDoValue?.assignee?.id || undefined,
+    assigneeUserId: toDoValue?.assignee?.id || null,
     title: toDoValue?.title || '',
     description: toDoValue?.description || '',
     dueDate: toDoValue?.dueDate || undefined,
@@ -87,6 +87,12 @@ export default function AddToDoModal({
       jsonObject.imageUrl = null;
     }
 
+    if (isEdit && !assigneeUserId) {
+      jsonObject.assigneeUserId = null;
+    }
+
+    console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>.');
+    console.log(jsonObject);
     try {
       if (isEdit && cardId) {
         await updateToDoCard(jsonObject, cardId);
@@ -114,7 +120,7 @@ export default function AddToDoModal({
   useEffect(() => {
     if (!isOpen) {
       reset({
-        assigneeUserId: undefined,
+        assigneeUserId: null,
         title: '',
         description: '',
         dueDate: undefined,

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -50,12 +50,13 @@ export default function AddToDoModal({
     handleSubmit,
     setValue,
     reset,
-    formState: { errors, isValid },
+    formState: { errors, isValid, isDirty },
   } = methods;
   const [tags, setTags] = useState<string[]>(toDoValue?.tags || []);
   const [column, setColumn] = useState(columnId);
   const { id } = useParams<{ id: string }>(); // 대시보드 id
   const [isEdit, setIsEdit] = useState(false);
+  const [isChange, setIsChange] = useState(false);
 
   const onSubmit: SubmitHandler<ToDoCardValue> = async (data) => {
     const { assigneeUserId, title, description, dueDate, imageUrl } = data;
@@ -91,8 +92,6 @@ export default function AddToDoModal({
       jsonObject.assigneeUserId = null;
     }
 
-    console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>.');
-    console.log(jsonObject);
     try {
       if (isEdit && cardId) {
         await updateToDoCard(jsonObject, cardId);
@@ -193,6 +192,7 @@ export default function AddToDoModal({
                 imageUrlValue={toDoValue?.imageUrl}
                 unregister={unregister}
                 size="76px"
+                setIsChange={setIsChange}
               />
             </div>
           </div>
@@ -208,6 +208,7 @@ export default function AddToDoModal({
               <button
                 type="submit"
                 className="h-[42px] w-full rounded bg-violet-primary text-center text-sm font-medium text-white disabled:bg-gray-400 md:w-[120px] md:text-base"
+                disabled={!(isDirty && isValid) && !isChange}
               >
                 수정
               </button>

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -182,7 +182,11 @@ export default function AddToDoModal({
               dueDateValue={toDoValue?.dueDate}
               isEdit={isEdit}
             />
-            <AddTagInput tags={tags} setTags={setTags} />
+            <AddTagInput
+              tags={tags}
+              setTags={setTags}
+              setIsChange={setIsChange}
+            />
             <div className="mb-4 flex flex-col gap-y-2">
               <p className="text-base font-medium md:text-lg">이미지</p>
               <ImageInputField

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -9,6 +9,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
 import { postToDoCard, postToDoCardImage, updateToDoCard } from '../../action';
 import AddDueDateInput from './add-due-date-input';
@@ -93,20 +94,14 @@ export default function AddToDoModal({
     if (isEdit && !assigneeUserId) {
       jsonObject.assigneeUserId = null;
     }
-
-    try {
-      if (isEdit && cardId) {
-        await updateToDoCard(jsonObject, cardId);
-      } else {
-        await postToDoCard(jsonObject);
-      }
-      onClose();
-    } catch (error) {
-      console.error(
-        isEdit ? '할 일 카드 수정 오류' : '할 일 카드 생성 오류',
-        error
-      );
+    let res;
+    if (isEdit && cardId) {
+      res = await updateToDoCard(jsonObject, cardId);
+    } else {
+      res = await postToDoCard(jsonObject);
     }
+    onClose();
+    toast.success(res.message);
   };
 
   useEffect(() => {

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -20,18 +20,19 @@ import ColumnDropdown from './column-dropdown';
 interface AddToDoModalProps {
   isOpen: boolean;
   onClose: () => void;
-  columnId: number;
+  columnIdProp: number;
   toDoValue?: CardData;
   cardId?: number;
 }
 export default function AddToDoModal({
   isOpen,
   onClose,
-  columnId,
+  columnIdProp,
   toDoValue,
   cardId,
 }: AddToDoModalProps) {
   const defaultValues = {
+    columnId: toDoValue?.columnId || columnIdProp,
     assigneeUserId: toDoValue?.assignee?.id || null,
     title: toDoValue?.title || '',
     description: toDoValue?.description || '',
@@ -53,18 +54,19 @@ export default function AddToDoModal({
     formState: { errors, isValid, isDirty },
   } = methods;
   const [tags, setTags] = useState<string[]>(toDoValue?.tags || []);
-  const [column, setColumn] = useState(columnId);
+  // const [column, setColumn] = useState(columnId);
   const { id } = useParams<{ id: string }>(); // 대시보드 id
   const [isEdit, setIsEdit] = useState(false);
   const [isChange, setIsChange] = useState(false);
 
   const onSubmit: SubmitHandler<ToDoCardValue> = async (data) => {
-    const { assigneeUserId, title, description, dueDate, imageUrl } = data;
+    const { assigneeUserId, title, description, dueDate, imageUrl, columnId } =
+      data;
 
     // NOTE - 필수값
     const jsonObject: { [key: string]: any } = {
       dashboardId: Number(id),
-      columnId: column,
+      columnId,
       title,
       description,
     };
@@ -119,6 +121,7 @@ export default function AddToDoModal({
   useEffect(() => {
     if (!isOpen) {
       reset({
+        columnId: columnIdProp,
         assigneeUserId: null,
         title: '',
         description: '',
@@ -128,7 +131,7 @@ export default function AddToDoModal({
       setTags([]);
       setIsEdit(false);
     }
-  }, [isOpen, reset]);
+  }, [isOpen, reset, columnIdProp]);
 
   if (!isOpen) return null;
 
@@ -149,11 +152,7 @@ export default function AddToDoModal({
           <div className="flex flex-grow flex-col gap-6 overflow-y-auto overflow-x-hidden">
             <div className="flex flex-col gap-2 md:flex-row">
               {isEdit && (
-                <ColumnDropdown
-                  dashboardId={id}
-                  columnId={column}
-                  setColumn={setColumn}
-                />
+                <ColumnDropdown dashboardId={id} columnId={columnIdProp} />
               )}
               <AssigneeUserDropdown
                 dashboardId={id}

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -131,7 +131,7 @@ export default function AddToDoModal({
       setTags([]);
       setIsEdit(false);
     }
-  }, [isOpen, reset, columnIdProp]);
+  }, [isOpen, reset, columnIdProp, toDoValue]);
 
   if (!isOpen) return null;
 

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/add-to-do-modal.tsx
@@ -91,17 +91,19 @@ export default function AddToDoModal({
       jsonObject.imageUrl = null;
     }
 
-    if (isEdit && !assigneeUserId) {
-      jsonObject.assigneeUserId = null;
+    try {
+      let res;
+      if (isEdit && cardId) {
+        res = await updateToDoCard(jsonObject, cardId);
+        // NOTE - 수정인 경우에만 toast
+        toast.success(res.message);
+      } else {
+        res = await postToDoCard(jsonObject);
+      }
+      onClose();
+    } catch (error: any) {
+      toast.error(error.message);
     }
-    let res;
-    if (isEdit && cardId) {
-      res = await updateToDoCard(jsonObject, cardId);
-    } else {
-      res = await postToDoCard(jsonObject);
-    }
-    onClose();
-    toast.success(res.message);
   };
 
   useEffect(() => {

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 'use client';
 
 import Dropdown from '@/app/components/dropdown';
@@ -7,6 +8,10 @@ import { DashboardMembers } from '@/types/members';
 import { getCookie } from 'cookies-next';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+
+/* eslint-disable */
+
+/* eslint-disable */
 
 interface AssigneeUserDropdownProps {
   dashboardId: string;
@@ -63,6 +68,10 @@ export default function AssigneeUserDropdown({
     setValue('assigneeUserId', userId);
   };
 
+  const handleDeleteItem = () => {
+    setValue('assigneeUserId', null);
+  };
+
   useEffect(() => {
     getMember();
   }, [dashboardId]);
@@ -86,11 +95,20 @@ export default function AssigneeUserDropdown({
             </div>
           ) : (
             <p className="text-sm font-normal text-gray-400">
-              이름을 입력해 주세요
+              담당자를 선택해 주세요
             </p>
           )}
         </Dropdown.Toggle>
         <Dropdown.List>
+          <Dropdown.Item>
+            {/* NOTE - 담당자 취소 */}
+            <div
+              className="flex h-full w-full text-sm font-normal text-gray-400"
+              onClick={() => handleDeleteItem()}
+            >
+              담당자를 선택해 주세요
+            </div>
+          </Dropdown.Item>
           {members.map((member) => (
             <Dropdown.Item key={member.userId}>
               <div

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/assignee-user-dropdown.tsx
@@ -65,11 +65,11 @@ export default function AssigneeUserDropdown({
 
   const handleItemClick = (userId: number) => {
     // 선택된 담당자 ID를 react-hook-form 필드에 설정
-    setValue('assigneeUserId', userId);
+    setValue('assigneeUserId', userId, { shouldDirty: true });
   };
 
   const handleDeleteItem = () => {
-    setValue('assigneeUserId', null);
+    setValue('assigneeUserId', null, { shouldDirty: true });
   };
 
   useEffect(() => {

--- a/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
+++ b/app/(dashboard)/dashboard/[id]/_components/to-do/column-dropdown.tsx
@@ -7,6 +7,7 @@ import { TEAM_BASE_URL } from '@/constants/TEAM_BASE_URL';
 import { ColumnData } from '@/types/card';
 import { getCookie } from 'cookies-next';
 import { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 /* eslint-disable */
 
@@ -15,16 +16,16 @@ import { useEffect, useState } from 'react';
 interface ColumnDropdownProps {
   dashboardId: string;
   columnId: number;
-  setColumn: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function ColumnDropdown({
   dashboardId,
   columnId,
-  setColumn,
 }: ColumnDropdownProps) {
   const [columns, setColumns] = useState<ColumnData[]>([]);
   const token = getCookie('token');
+
+  const { register, setValue } = useFormContext();
 
   async function getColumns() {
     const res = await fetch(
@@ -43,7 +44,7 @@ export default function ColumnDropdown({
   }
 
   const handleItemClick = (id: number) => {
-    setColumn(id);
+    setValue('columnId', id, { shouldDirty: true });
   };
 
   useEffect(() => {
@@ -76,6 +77,13 @@ export default function ColumnDropdown({
                   }
                 }}
               >
+                <input
+                  className="appearance-none"
+                  type="radio"
+                  id={`columnId-${column.id}`}
+                  value={column.id}
+                  {...register('columnId')}
+                />
                 <ColumnTag title={column.title} />
               </div>
             </Dropdown.Item>

--- a/app/(dashboard)/dashboard/[id]/action.ts
+++ b/app/(dashboard)/dashboard/[id]/action.ts
@@ -48,7 +48,7 @@ export async function postToDoCard(jsonObject: { [key: string]: any }) {
       case 404:
         throw new Error(data.message);
       default:
-        throw new Error('서버 오류가 발생했습니다');
+        throw new Error('카드 생성 중 오류가 발생했습니다');
     }
   }
 
@@ -72,15 +72,21 @@ export async function updateToDoCard(
     body: JSON.stringify(jsonObject),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    const errorData = await response.json();
-    console.error('카드 수정 실패:', errorData);
-    throw new Error('카드 수정 실패');
+    switch (response.status) {
+      case 400:
+        throw new Error(data.message);
+      case 404:
+        throw new Error(data.message);
+      default:
+        throw new Error('카드 수정 중 오류가 발생했습니다');
+    }
   }
 
-  const data = await response.json();
   revalidatePath(`/dashboard/${jsonObject.dashboardId}`);
-  return data;
+  return { message: '카드가 수정되었습니다.' };
 }
 
 export async function postToDoCardComment(commentData: {

--- a/app/components/column-tag.tsx
+++ b/app/components/column-tag.tsx
@@ -1,6 +1,6 @@
 export default function ColumnTag({ title }: { title: string }) {
   return (
-    <div className="flex h-[20px] w-[55px] items-center justify-center gap-x-[6px] rounded-[11px] bg-violet-primary/10 md:h-[22px] md:w-[60px]">
+    <div className="flex h-[20px] items-center justify-center gap-x-[6px] rounded-[11px] bg-violet-primary/10 px-[8px] py-[4px] md:h-[22px]">
       <div className="size-[6px] rounded-full bg-violet-primary" />
       <p className="text-[10px] text-violet-primary md:text-xs">{title}</p>
     </div>

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -7,12 +7,14 @@ export default function ImageInputField({
   imageUrlValue,
   unregister,
   size,
+  setIsChange,
 }: {
   id: string;
   setValue: any;
   unregister?: any;
   imageUrlValue?: string | null;
   size?: string;
+  setIsChange?: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [initialImage, setInitialImage] = useState<string | null>(
@@ -24,14 +26,19 @@ export default function ImageInputField({
     if (file) {
       setSelectedImage(file);
       setValue(id, file);
+      if (setIsChange) {
+        setIsChange(true);
+      }
     }
   };
 
-  // TODO - 수정하기에서 이미지 x 누른 후 그대로 수정하면 오류남
   const handleImageDelete = () => {
     unregister(id);
     setSelectedImage(null);
     setInitialImage(null);
+    if (setIsChange) {
+      setIsChange(true);
+    }
   };
 
   return (

--- a/lib/schemas/createToDo.ts
+++ b/lib/schemas/createToDo.ts
@@ -15,6 +15,7 @@ const imageFileValidation = (value: any) => {
 };
 
 const createTodoSchema = yup.object().shape({
+  columnId: yup.number().required(),
   assigneeUserId: yup.number().nullable(),
   title: yup
     .string()

--- a/types/toDoCard.ts
+++ b/types/toDoCard.ts
@@ -1,4 +1,5 @@
 export interface ToDoCardValue {
+  columnId: number;
   assigneeUserId?: number | null;
   title: string;
   description: string;


### PR DESCRIPTION
## #️⃣연관된 이슈
#143,147

## 📝작업 내용

- [x] 수정하기에서 제목과 내용이 빈 값일 경우 수정 버튼을 비활성화
- [x] 수정하기에서 기존 값에서 하나라도 변경되는 경우 버튼 활성화 
- [x] 컬럼id도 react-hook-form으로 관리 리팩토링 
- [x] 컬럼 태그 글씨 overflow 되는 디자인 수정 
- [x] 카드 수정 후 바로 다시 수정하는 경우 수정하기 이전 값이 있는 버그 해결 
- [x] 카드 수정 후 토스트 

## 📷스크린샷 (선택)
<img src="https://github.com/Sprint-Part3-14Team/14team-project/assets/135966211/d6d3045d-19fd-4824-ba6f-1601acfbe945" width="50%" height="50%"/>

## 💬리뷰 요구사항(선택)
버그 있으면 말씀해 주세요 ! 
