### PR TITLE
🐛 fix: 이미지가 공백이여도 기본 프로필 이미지로 추가 및 수정 버튼 로직 변경

### DIFF
--- a/app/(dashboard)/_components/edit-profile-form.tsx
+++ b/app/(dashboard)/_components/edit-profile-form.tsx
@@ -20,9 +20,8 @@ export default function EditProfileForm() {
     register,
     setValue,
     handleSubmit,
-    watch,
     unregister,
-    formState: { errors, isValid, isDirty },
+    formState: { errors },
   } = useForm<EditProfile>({
     resolver: yupResolver(editProfileSchema),
     mode: 'onChange',
@@ -30,12 +29,6 @@ export default function EditProfileForm() {
 
   const token = getCookie('token');
   const [user, setUser] = useState<User | null>(null);
-
-  const profileImageUrlInput = watch('profileImageUrl');
-  const nicknameInput = watch('nickname');
-
-  const isFormValid =
-    isValid && (!!profileImageUrlInput || nicknameInput !== '');
 
   const onSubmit: SubmitHandler<EditProfile> = async (data) => {
     const { profileImageUrl, nickname } = data;
@@ -102,7 +95,6 @@ export default function EditProfileForm() {
             type="submit"
             variant="mobile84x28"
             className="ml-auto mt-4 rounded bg-violet-primary text-white disabled:cursor-not-allowed disabled:bg-gray-400"
-            disabled={!isFormValid || !isDirty}
           >
             저장
           </Button>

--- a/app/(dashboard)/_components/edit-profile-form.tsx
+++ b/app/(dashboard)/_components/edit-profile-form.tsx
@@ -21,7 +21,8 @@ export default function EditProfileForm() {
     setValue,
     handleSubmit,
     watch,
-    formState: { errors, isValid },
+    unregister,
+    formState: { errors, isValid, isDirty },
   } = useForm<EditProfile>({
     resolver: yupResolver(editProfileSchema),
     mode: 'onChange',
@@ -40,7 +41,12 @@ export default function EditProfileForm() {
     const { profileImageUrl, nickname } = data;
 
     const formData = new FormData();
-    formData.append('image', profileImageUrl!);
+
+    if (profileImageUrl) {
+      formData.append('image', profileImageUrl);
+    } else {
+      formData.append('image', 'null');
+    }
 
     const res = await editProfile(formData, nickname);
     // NOTE - 성공 메시지 출력
@@ -69,7 +75,12 @@ export default function EditProfileForm() {
         onSubmit={handleSubmit(onSubmit)}
         className="mt-6 flex w-full flex-col md:mt-8 md:flex-row md:gap-x-4"
       >
-        <ImageInputField id="profileImageUrl" setValue={setValue} />
+        <ImageInputField
+          id="profileImageUrl"
+          setValue={setValue}
+          imageUrlValue={user?.profileImageUrl}
+          unregister={unregister}
+        />
         <div className="flex w-full flex-col">
           <InputField
             id="email"
@@ -91,7 +102,7 @@ export default function EditProfileForm() {
             type="submit"
             variant="mobile84x28"
             className="ml-auto mt-4 rounded bg-violet-primary text-white disabled:cursor-not-allowed disabled:bg-gray-400"
-            disabled={!isFormValid}
+            disabled={!isFormValid || !isDirty}
           >
             저장
           </Button>

--- a/app/(dashboard)/mypage/actions.ts
+++ b/app/(dashboard)/mypage/actions.ts
@@ -47,9 +47,10 @@ export async function editProfile(formData?: FormData, nickname?: string) {
 
   // 프로필 업데이트 함수
   async function updateProfile(uploadedImageUrl?: string, nick?: string) {
-    const body: { nickname?: string; profileImageUrl?: string } = {};
+    const body: { nickname?: string; profileImageUrl?: string | null } = {};
     if (nick !== undefined && nick !== '') body.nickname = nick;
     if (uploadedImageUrl !== undefined) body.profileImageUrl = uploadedImageUrl;
+    if (uploadedImageUrl === undefined) body.profileImageUrl = null;
 
     const response = await fetch(`${TEAM_BASE_URL}/users/me`, {
       method: 'PUT',
@@ -68,7 +69,7 @@ export async function editProfile(formData?: FormData, nickname?: string) {
   }
 
   // 이미지가 있는 경우
-  if (formData !== undefined) {
+  if (formData !== undefined && formData.get('image') !== 'null') {
     const uploadedImageUrl = await uploadImage(formData);
     if (uploadedImageUrl) {
       return updateProfile(uploadedImageUrl, nickname);

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function ImageInputField({
   id,
@@ -15,9 +15,13 @@ export default function ImageInputField({
   size?: string;
 }) {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
-  const [initialImage, setInitialImage] = useState<string | null>(
-    imageUrlValue || null
-  );
+  const [initialImage, setInitialImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (imageUrlValue) {
+      setInitialImage(imageUrlValue);
+    }
+  }, [imageUrlValue]);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## 📝작업 내용

마이페이지에서 수정할 시 이미지를 제거하면 기본 이미지로 변경 가능하도록 바꾸었습니다.
버튼은 고민이 많았는데 수정에 valid가 필요한가에 대해서 주지 않아도 기본값을 보내므로 유효성 검사를 하지 않아도 되겠다고 판단하였습니다.
(이미지가 있을때, 뺏을때 혹은 닉네임을 그대로, 변경시 모두 유효성이 필요 없으며 이미지 닉네임이 모두 공백이면 기본 프로필 이미지로 변경하고 닉네임은 그대로 가게되므로 유효성 검사가 필요 없다고 생각하였습니다.)