### PR TITLE
💄 design: 대시보드 프로필 ml 및 이미지 인풋 스타일 변경

### DIFF
--- a/app/(dashboard)/_components/todo-card.tsx
+++ b/app/(dashboard)/_components/todo-card.tsx
@@ -67,7 +67,7 @@ export default function ToDoCard({
                   </p>
                 </div>
               )}
-              <div className="flex items-center gap-x-[6px]">
+              <div className="ml-auto flex items-center gap-x-[6px]">
                 <div className="relative size-[22px] md:size-6">
                   {/* TODO 모바일일 때 size가 22px PC가 24px인데 어떻게 주어야 좋을까요 */}
                   {/* NOTE - 담당자 필수값 아닙니다! 없을 때도 있어요 */}

--- a/app/components/image-input-field.tsx
+++ b/app/components/image-input-field.tsx
@@ -87,15 +87,20 @@ export default function ImageInputField({
             className="hidden"
           />
           <div className="absolute left-1/2 top-1/2 size-5 -translate-x-1/2 -translate-y-1/2 md:size-[30px]">
-            <Image
-              src="/icons/icon_purple_add.svg"
-              alt="Add Image"
-              sizes="(min-width: 768px) 100vw"
-              fill
-            />
+            <svg
+              viewBox="0 0 30 30"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.5783 16.4221H7.418C7.01898 16.4221 6.68224 16.2848 6.40778 16.0104C6.13332 15.7359 5.99609 15.3992 5.99609 15.0002C5.99609 14.6012 6.13332 14.2645 6.40778 13.99C6.68224 13.7155 7.01898 13.5783 7.418 13.5783H13.5783V7.418C13.5783 7.01898 13.7155 6.68224 13.99 6.40778C14.2645 6.13332 14.6012 5.99609 15.0002 5.99609C15.3992 5.99609 15.7359 6.13332 16.0104 6.40778C16.2848 6.68224 16.4221 7.01898 16.4221 7.418V13.5783H22.5824C22.9814 13.5783 23.3181 13.7155 23.5926 13.99C23.8671 14.2645 24.0043 14.6012 24.0043 15.0002C24.0043 15.3992 23.8671 15.7359 23.5926 16.0104C23.3181 16.2848 22.9814 16.4221 22.5824 16.4221H16.4221V22.5824C16.4221 22.9814 16.2848 23.3181 16.0104 23.5926C15.7359 23.8671 15.3992 24.0043 15.0002 24.0043C14.6012 24.0043 14.2645 23.8671 13.99 23.5926C13.7155 23.3181 13.5783 22.9814 13.5783 22.5824V16.4221Z"
+                fill="none"
+                className="fill-primary"
+              />
+            </svg>
           </div>
           <div
-            className="size-[100px] cursor-pointer rounded-md bg-gray-200 md:size-[182px]"
+            className="size-[100px] cursor-pointer rounded-md bg-secondary-foreground md:size-[182px]"
             style={{ width: size, height: size }}
           />
         </label>


### PR DESCRIPTION
## 📝작업 내용
1. 대시보드 프로필 이미지 왼쪽으로 통일
2. 이미지 인풋 다크모드에 맞게 색상 변경

